### PR TITLE
Parameterize filenames

### DIFF
--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -39,7 +39,8 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx context.Context) error {
 		}
 	}
 	defer os.RemoveAll(dir) //nolint:errcheck
-	if err := config.WriteYamlConfig(dir); err != nil {
+	configFile := "config.yaml"
+	if err := config.WriteYamlConfig(dir, configFile); err != nil {
 		return err
 	}
 
@@ -50,7 +51,7 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx context.Context) error {
 	pupsArgs := "--skip-tags=precompile,migrate,db"
 	builder := docker.DockerBuilder{
 		Config:    config,
-		Stdin:     strings.NewReader(config.Dockerfile(pupsArgs, r.BakeEnv)),
+		Stdin:     strings.NewReader(config.Dockerfile(pupsArgs, r.BakeEnv, configFile)),
 		Dir:       dir,
 		Namespace: namespace,
 		ImageTag:  r.Tag,

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -144,7 +144,10 @@ func (config *Config) Yaml() string {
 	return strings.Join(config.rawYaml, "_FILE_SEPERATOR_")
 }
 
-func (config *Config) Dockerfile(pupsArgs string, bakeEnv bool) string {
+func (config *Config) Dockerfile(pupsArgs string, bakeEnv bool, configFile string) string {
+	if configFile == "" {
+		configFile = "config.yaml"
+	}
 	builder := strings.Builder{}
 	builder.WriteString("ARG dockerfile_from_image=" + config.BaseImage + "\n")
 	builder.WriteString("FROM ${dockerfile_from_image}\n")
@@ -155,7 +158,7 @@ func (config *Config) Dockerfile(pupsArgs string, bakeEnv bool) string {
 		builder.WriteString(config.dockerfileDefaultEnvs() + "\n")
 	}
 	builder.WriteString(config.dockerfileExpose() + "\n")
-	builder.WriteString("COPY config.yaml /temp-config.yaml\n")
+	builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
 	builder.WriteString("RUN " +
 		"cat /temp-config.yaml | /usr/local/bin/pups " + pupsArgs + " --stdin " +
 		"&& rm /temp-config.yaml\n")
@@ -163,8 +166,11 @@ func (config *Config) Dockerfile(pupsArgs string, bakeEnv bool) string {
 	return builder.String()
 }
 
-func (config *Config) WriteYamlConfig(dir string) error {
-	file := strings.TrimRight(dir, "/") + "/config.yaml"
+func (config *Config) WriteYamlConfig(dir string, configFile string) error {
+	if configFile == "" {
+		configFile = "config.yaml"
+	}
+	file := strings.TrimRight(dir, "/") + "/" + configFile
 	if err := os.WriteFile(file, []byte(config.Yaml()), 0660); err != nil {
 		return errors.New("error writing config file " + file)
 	}

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Config", func() {
 	})
 
 	It("can write raw yaml config", func() {
-		err := conf.WriteYamlConfig(testDir)
+		err := conf.WriteYamlConfig(testDir, "config.yaml")
 		Expect(err).To(BeNil())
 		out, err := os.ReadFile(testDir + "/config.yaml")
 		Expect(err).To(BeNil())
@@ -39,7 +39,7 @@ var _ = Describe("Config", func() {
 	})
 
 	It("can convert pups config to dockerfile format and bake in default env", func() {
-		dockerfile := conf.Dockerfile("", false)
+		dockerfile := conf.Dockerfile("", false, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
 ARG DISCOURSE_DB_HOST
 ARG DISCOURSE_DB_PASSWORD
@@ -77,7 +77,7 @@ CMD ["/sbin/boot"]`))
 	})
 
 	It("can generate a dockerfile with all env baked into the image", func() {
-		dockerfile := conf.Dockerfile("", true)
+		dockerfile := conf.Dockerfile("", true, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
 ARG DISCOURSE_DB_HOST
 ARG DISCOURSE_DB_PASSWORD


### PR DESCRIPTION
Parameterize which filename to write to (write config) and which file is copied from (dockerfile)

Allows for external apps to control which filenames the config writes to, so multiple configuration files and dockerfiles can be written to the same path without conflict.