### PR TITLE
build/compile split - launcher calls

### DIFF
--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -102,7 +102,7 @@ func (r *DockerConfigureCmd) Run(cli *Cli, ctx *context.Context) error {
 		PupsArgs:       "--tags=db,precompile",
 		FromImageName:  namespace + "/" + r.Config + sourceTag,
 		SavedImageName: namespace + "/" + r.Config + targetTag,
-		ExtraEnv:       []string{"SKIP_EMBER_CLI_COMPILE=1"},
+		ExtraEnv:       []string{},
 		Ctx:            ctx,
 		ContainerId:    containerId,
 	}
@@ -122,7 +122,7 @@ func (r *DockerMigrateCmd) Run(cli *Cli, ctx *context.Context) error {
 		return errors.New("YAML syntax error. Please check your containers/*.yml config files.")
 	}
 	containerId := "discourse-build-" + uuid.NewString()
-	env := []string{"SKIP_EMBER_CLI_COMPILE=1"}
+	env := []string{}
 	if r.SkipPostDeploymentMigrations {
 		env = append(env, "SKIP_POST_DEPLOYMENT_MIGRATIONS=1")
 	}

--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -57,13 +57,11 @@ var _ = Describe("Build", func() {
 			// docker build's stdin is a dockerfile
 			Expect(buf.String()).To(ContainSubstring("COPY config.yaml /temp-config.yaml"))
 			Expect(buf.String()).To(ContainSubstring("--skip-tags=precompile,migrate,db"))
-			Expect(buf.String()).ToNot(ContainSubstring("SKIP_EMBER_CLI_COMPILE=1"))
 		}
 
 		var checkMigrateCmd = func(cmd exec.Cmd) {
 			Expect(cmd.String()).To(ContainSubstring("docker run"))
 			Expect(cmd.String()).To(ContainSubstring("--env DISCOURSE_DEVELOPER_EMAILS"))
-			Expect(cmd.String()).To(ContainSubstring("--env SKIP_EMBER_CLI_COMPILE=1"))
 			// no commit after, we expect an --rm as the container isn't needed after it is stopped
 			Expect(cmd.String()).To(ContainSubstring("--rm"))
 			Expect(cmd.Env).To(ContainElement("DISCOURSE_DB_PASSWORD=SOME_SECRET"))
@@ -97,7 +95,6 @@ var _ = Describe("Build", func() {
 					"--env RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR " +
 					"--env UNICORN_SIDEKIQS " +
 					"--env UNICORN_WORKERS " +
-					"--env SKIP_EMBER_CLI_COMPILE=1 " +
 					"--volume /var/discourse/shared/web-only:/shared " +
 					"--volume /var/discourse/shared/web-only/log/var-log:/var/log " +
 					"--link data:data " +
@@ -220,7 +217,6 @@ var _ = Describe("Build", func() {
 			Expect(cmd.String()).To(ContainSubstring("docker run"))
 			Expect(cmd.String()).To(ContainSubstring("--env DISCOURSE_DEVELOPER_EMAILS"))
 			Expect(cmd.String()).To(ContainSubstring("--env SKIP_POST_DEPLOYMENT_MIGRATIONS=1"))
-			Expect(cmd.String()).To(ContainSubstring("--env SKIP_EMBER_CLI_COMPILE=1"))
 			// no commit after, we expect an --rm as the container isn't needed after it is stopped
 			Expect(cmd.String()).To(ContainSubstring("--rm"))
 			Expect(cmd.Env).To(ContainElement("DISCOURSE_DB_PASSWORD=SOME_SECRET"))


### PR DESCRIPTION
No need to pass SKIP_EMBER_CLI_COMPILE=1 if build/compile split calls different asset:precompile tasks.

Depends on https://github.com/discourse/discourse_docker/pull/878