### PR TITLE
FIX: git push the tag needs a named origin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test:
 .PHONY: release
 release:
 	export VERSION=$(shell cd v2; go run ./... --version) &&\
-	git tag $$VERSION && git push refs/tags/$$VERSION
+	git tag $$VERSION && git push origin refs/tags/$$VERSION


### PR DESCRIPTION
origin is default named branch - this should be a safe assumption for the release task in most cases.