### PR TITLE
DEV: rename launcher2 references properly to launcher

### DIFF
--- a/v2/main.go
+++ b/v2/main.go
@@ -34,7 +34,7 @@ type Cli struct {
 	RestartCmd RestartCmd `cmd:"" name:"restart" help:"Stops then starts container."`
 	RebuildCmd RebuildCmd `cmd:"" name:"rebuild" help:"Builds new image, then destroys old container, and starts new container."`
 
-	InstallCompletions kongplete.InstallCompletions `cmd:"" aliases:"sh" help:"Print shell autocompletions. Add output to dotfiles, or 'source <(./launcher2 sh)'."`
+	InstallCompletions kongplete.InstallCompletions `cmd:"" aliases:"sh" help:"Print shell autocompletions. Add output to dotfiles, or 'source <(./launcher sh)'."`
 }
 
 func main() {

--- a/v2/utils/find_config_test.go
+++ b/v2/utils/find_config_test.go
@@ -11,29 +11,29 @@ import (
 var _ = Describe("FindConfig", func() {
 
 	It("Parses and returns yml or yaml files", func() {
-		os.Setenv("COMP_LINE", "launcher2 build --conf-dir ../test/containers")
+		os.Setenv("COMP_LINE", "launcher build --conf-dir ../test/containers")
 		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
 	})
 
 	It("Parses and returns yml or yaml files with trailing slash", func() {
-		os.Setenv("COMP_LINE", "launcher2 build --conf-dir ../test/containers/")
+		os.Setenv("COMP_LINE", "launcher build --conf-dir ../test/containers/")
 		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
 	})
 
 	It("Parses and returns yml or yaml files on equals", func() {
-		os.Setenv("COMP_LINE", "launcher2 --conf-dir=../test/containers other args")
+		os.Setenv("COMP_LINE", "launcher --conf-dir=../test/containers other args")
 		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
 	})
 
 	It("doesn't error when dir does not exist when set", func() {
-		os.Setenv("COMP_LINE", "launcher2 --conf-dir=./does-not-exist")
+		os.Setenv("COMP_LINE", "launcher --conf-dir=./does-not-exist")
 		Expect(utils.FindConfigNames()).To(BeEmpty())
 	})
 
 	It("doesn't error when dir does not exist", func() {
 		//by default it look is in ./containers directory, which does not exist
 		// in this directory
-		os.Setenv("COMP_LINE", "launcher2")
+		os.Setenv("COMP_LINE", "launcher")
 		Expect(utils.FindConfigNames()).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
Update helptext for autocomplete, update test examples