### PR TITLE
FIX: disable cgo when compiling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         working-directory: ./v2
         env:
           GH_TOKEN: ${{ github.token }}
+          CGO_ENABLED: 0
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           BIN_FILE: launcher


### PR DESCRIPTION
cgo is enabled by default which requires libc.so on existing systems

Disabling cgo ensures that the compiled binary is more portable.

Test run on linux x86-64 system currently outputs:
`/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./bin/launcher)`

Expected: no errors