### PR TITLE
FIX: remove params from yaml parsing

### DIFF
--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -27,7 +27,6 @@ type Config struct {
 	Docker_Args     string            `yaml:,omitempty`
 	Templates       []string          `yaml:templates,omitempty`
 	Expose          []string          `yaml:expose,omitempty`
-	Params          map[string]string `yaml:params,omitempty`
 	Env             map[string]string `yaml:env,omitempty`
 	Labels          map[string]string `yaml:labels,omitempty`
 	Volumes         []struct {


### PR DESCRIPTION
Params isn't used in launcher, and there are some cases where it's a dynamic entry, such as with pups' merge command which merges a nested yaml map into a yaml file.

Relinquish control of Params to not throw an error with different types of params.