### PR TITLE
Bump default base image to 2.0.20250226-0128

### DIFF
--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -10,7 +10,7 @@ import (
 const Version = "v2.0.2"
 
 const DefaultNamespace = "local_discourse"
-const DefaultBaseImage = "discourse/base:2.0.20240825-0027"
+const DefaultBaseImage = "discourse/base:2.0.20250226-0128"
 
 // Known secrets, or otherwise not public info from config so we can build public images
 var KnownSecrets = []string{


### PR DESCRIPTION
This should really be left to the site configuration, and we should *probably* have this value baked into `web.template.yml`, and then overridden in a specific site.yml when needed... but this is where we are today.