### PR TITLE
DEV: update base image to be discourse/base:release

### DIFF
--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -10,7 +10,7 @@ import (
 const Version = "v2.0.3"
 
 const DefaultNamespace = "local_discourse"
-const DefaultBaseImage = "discourse/base:2.0.20250226-0128"
+const DefaultBaseImage = "discourse/base:release"
 
 // Known secrets, or otherwise not public info from config so we can build public images
 var KnownSecrets = []string{

--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const Version = "v2.0.3"
+const Version = "v2.0.4"
 
 const DefaultNamespace = "local_discourse"
 const DefaultBaseImage = "discourse/base:release"


### PR DESCRIPTION
Now that base image is in the web.template.yml, fall back to discourse/base:release as this will not get bumped. It is a more sane fallback.