### PR TITLE
FIX: error out if no base image provided in config

### DIFF
--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -67,7 +67,6 @@ func LoadConfig(dir string, configName string, includeTemplates bool, templatesD
 	config := &Config{
 		Name:         configName,
 		Boot_Command: defaultBootCommand,
-		Base_Image:   utils.DefaultBaseImage,
 	}
 
 	matched, _ := regexp.MatchString("[[:upper:]/ !@#$%^&*()+~`=]", configName)
@@ -120,6 +119,10 @@ func LoadConfig(dir string, configName string, includeTemplates bool, templatesD
 	for k, v := range config.Env {
 		val := strings.ReplaceAll(v, "{{config}}", config.Name)
 		config.Env[k] = val
+	}
+
+	if config.Base_Image == "" {
+		return nil, errors.New("No base image specified in config! Set base image with `base_image: {imagename}`")
 	}
 
 	return config, nil

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -58,4 +58,9 @@ var _ = Describe("Config", func() {
 			Expect(config.DockerHostname("asdf!@#")).To(Equal("asdf---"))
 		})
 	})
+	It("should error if no base config LoadConfig to load yaml configuration", func() {
+		_, err := config.LoadConfig("../test/containers", "test-no-base-image", true, "../test")
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(Equal("No base image specified in config! Set base image with `base_image: {imagename}`"))
+	})
 })

--- a/v2/test/templates/web.template.yml
+++ b/v2/test/templates/web.template.yml
@@ -1,3 +1,4 @@
+base_image: discourse/base:2.0.20250226-0128
 env:
   # You can have redis on a different box
   RAILS_ENV: 'production'

--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -10,7 +10,6 @@ import (
 const Version = "v2.0.4"
 
 const DefaultNamespace = "local_discourse"
-const DefaultBaseImage = "discourse/base:release"
 
 // Known secrets, or otherwise not public info from config so we can build public images
 var KnownSecrets = []string{

--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const Version = "v2.0.4"
+const Version = "v2.0.5"
 
 const DefaultNamespace = "local_discourse"
 


### PR DESCRIPTION
It is currently dangerous to rely on `:release` as a fallback base image. Since there is no good floating tags currently to pin to, error out instead.