### PR TITLE
FIX: append os.Environ to docker build and docker run calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  fmt:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -25,6 +25,18 @@ jobs:
           if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then
             exit 1
           fi
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ">=1.22.0"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1
 
   test:
     runs-on: ubuntu-latest
@@ -45,7 +57,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [fmt, lint, test]
     steps:
       - uses: actions/checkout@v4
       - name: build and release
@@ -58,7 +70,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [lint, test, create_github_release]
+    needs: [fmt, lint, test, create_github_release]
     strategy:
       matrix:
         goos: [linux, darwin]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           go-version: ">=1.22.0"
       - name: golangci-lint
+        working-directory: ./v2
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,10 @@ jobs:
         with:
           go-version: ">=1.22.0"
       - name: golangci-lint
-        working-directory: ./v2
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
+          working-directory: ./v2
 
   test:
     runs-on: ubuntu-latest

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -29,7 +29,7 @@ type DockerBuildCmd struct {
 func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 	config, err := config.LoadConfig(cli.ConfDir, r.Config, true, cli.TemplatesDir)
 	if err != nil {
-		return errors.New("YAML syntax error. Please check your containers/*.yml config files.")
+		return errors.New("YAML syntax error. Please check your containers/*.yml config files")
 	}
 
 	dir := cli.BuildDir + "/" + r.Config
@@ -57,7 +57,9 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 		return err
 	}
 	cleaner := CleanCmd{Config: r.Config}
-	cleaner.Run(cli)
+	if err := cleaner.Run(cli); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -72,7 +74,7 @@ func (r *DockerConfigureCmd) Run(cli *Cli, ctx *context.Context) error {
 	config, err := config.LoadConfig(cli.ConfDir, r.Config, true, cli.TemplatesDir)
 
 	if err != nil {
-		return errors.New("YAML syntax error. Please check your containers/*.yml config files.")
+		return errors.New("YAML syntax error. Please check your containers/*.yml config files")
 	}
 
 	var uuidString string
@@ -119,7 +121,7 @@ type DockerMigrateCmd struct {
 func (r *DockerMigrateCmd) Run(cli *Cli, ctx *context.Context) error {
 	config, err := config.LoadConfig(cli.ConfDir, r.Config, true, cli.TemplatesDir)
 	if err != nil {
-		return errors.New("YAML syntax error. Please check your containers/*.yml config files.")
+		return errors.New("YAML syntax error. Please check your containers/*.yml config files")
 	}
 	containerId := "discourse-build-" + uuid.NewString()
 	env := []string{"SKIP_EMBER_CLI_COMPILE=1"}
@@ -172,7 +174,7 @@ type CleanCmd struct {
 
 func (r *CleanCmd) Run(cli *Cli) error {
 	dir := cli.BuildDir + "/" + r.Config
-	os.Remove(dir + "/config.yaml")
+	os.Remove(dir + "/config.yaml") //nolint:errcheck
 	if err := os.Remove(dir); err != nil {
 		return err
 	}

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -59,6 +59,7 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 	if err := builder.Run(); err != nil {
 		return err
 	}
+	os.RemoveAll(cli.BuildDir) //nolint:errcheck
 	return nil
 }
 

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -34,8 +34,11 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 
 	dir := cli.BuildDir
 	if dir == "" {
-		dir, _ = os.MkdirTemp("", "launcher") //nolint:errcheck
+		if dir, err = os.MkdirTemp("", "launcher"); err != nil {
+			return errors.New("cannot create temp directory")
+		}
 	}
+	defer os.RemoveAll(dir) //nolint:errcheck
 	if err := config.WriteYamlConfig(dir); err != nil {
 		return err
 	}
@@ -56,7 +59,6 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 	if err := builder.Run(); err != nil {
 		return err
 	}
-	os.RemoveAll(dir) //nolint:errcheck
 	return nil
 }
 

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -32,10 +32,10 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 		return errors.New("YAML syntax error. Please check your containers/*.yml config files")
 	}
 
-	if cli.BuildDir == "" {
-		cli.BuildDir, _ = os.MkdirTemp("", "launcher") //nolint:errcheck
+	dir := cli.BuildDir
+	if dir == "" {
+		dir, _ = os.MkdirTemp("", "launcher") //nolint:errcheck
 	}
-	dir := cli.BuildDir + "/" + r.Config
 	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsExist(err) {
 		return err
 	}
@@ -59,7 +59,7 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 	if err := builder.Run(); err != nil {
 		return err
 	}
-	os.RemoveAll(cli.BuildDir) //nolint:errcheck
+	os.RemoveAll(dir) //nolint:errcheck
 	return nil
 }
 

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -36,9 +36,6 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 	if dir == "" {
 		dir, _ = os.MkdirTemp("", "launcher") //nolint:errcheck
 	}
-	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsExist(err) {
-		return err
-	}
 	if err := config.WriteYamlConfig(dir); err != nil {
 		return err
 	}

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -32,6 +32,9 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 		return errors.New("YAML syntax error. Please check your containers/*.yml config files")
 	}
 
+	if cli.BuildDir == "" {
+		cli.BuildDir, _ = os.MkdirTemp("", "launcher") //nolint:errcheck
+	}
 	dir := cli.BuildDir + "/" + r.Config
 	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsExist(err) {
 		return err
@@ -56,11 +59,6 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx *context.Context) error {
 	if err := builder.Run(); err != nil {
 		return err
 	}
-	cleaner := CleanCmd{Config: r.Config}
-	if err := cleaner.Run(cli); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -163,19 +161,6 @@ func (r *DockerBootstrapCmd) Run(cli *Cli, ctx *context.Context) error {
 		return err
 	}
 	if err := configureStep.Run(cli, ctx); err != nil {
-		return err
-	}
-	return nil
-}
-
-type CleanCmd struct {
-	Config string `arg:"" name:"config" help:"config to clean" predictor:"config"`
-}
-
-func (r *CleanCmd) Run(cli *Cli) error {
-	dir := cli.BuildDir + "/" + r.Config
-	os.Remove(dir + "/config.yaml") //nolint:errcheck
-	if err := os.Remove(dir); err != nil {
 		return err
 	}
 	return nil

--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -39,10 +39,6 @@ var _ = Describe("Build", func() {
 		utils.CmdRunner = CreateNewFakeCmdRunner()
 	})
 
-	AfterEach(func() {
-		os.RemoveAll(testDir) //nolint:errcheck
-	})
-
 	Context("When running build commands", func() {
 		var checkBuildCmd = func(cmd exec.Cmd) {
 			Expect(cmd.String()).To(ContainSubstring("docker build"))
@@ -58,6 +54,10 @@ var _ = Describe("Build", func() {
 			Expect(buf.String()).To(ContainSubstring("COPY config.yaml /temp-config.yaml"))
 			Expect(buf.String()).To(ContainSubstring("--skip-tags=precompile,migrate,db"))
 			Expect(buf.String()).ToNot(ContainSubstring("SKIP_EMBER_CLI_COMPILE=1"))
+
+			// Ensure we clean up the temp dir after building
+				_, err := os.Stat(testDir)
+				Expect(err).To(MatchError(os.IsNotExist, "IsNotExist"))
 		}
 
 		var checkMigrateCmd = func(cmd exec.Cmd) {

--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Build", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(testDir)
+		os.RemoveAll(testDir) //nolint:errcheck
 	})
 
 	Context("When running build commands", func() {
@@ -53,7 +53,7 @@ var _ = Describe("Build", func() {
 			Expect(cmd.Env).ToNot(ContainElement("DISCOURSE_DB_PASSWORD=SOME_SECRET"))
 			Expect(cmd.Env).ToNot(ContainElement("DISCOURSEDB_SOCKET="))
 			buf := new(strings.Builder)
-			io.Copy(buf, cmd.Stdin)
+			io.Copy(buf, cmd.Stdin) //nolint:errcheck
 			// docker build's stdin is a dockerfile
 			Expect(buf.String()).To(ContainSubstring("COPY config.yaml /temp-config.yaml"))
 			Expect(buf.String()).To(ContainSubstring("--skip-tags=precompile,migrate,db"))
@@ -68,7 +68,7 @@ var _ = Describe("Build", func() {
 			Expect(cmd.String()).To(ContainSubstring("--rm"))
 			Expect(cmd.Env).To(ContainElement("DISCOURSE_DB_PASSWORD=SOME_SECRET"))
 			buf := new(strings.Builder)
-			io.Copy(buf, cmd.Stdin)
+			io.Copy(buf, cmd.Stdin) //nolint:errcheck
 			// docker run's stdin is a pups config
 			Expect(buf.String()).To(ContainSubstring("path: /etc/service/nginx/run"))
 		}
@@ -134,7 +134,7 @@ var _ = Describe("Build", func() {
 			))
 
 			buf := new(strings.Builder)
-			io.Copy(buf, cmd.Stdin)
+			io.Copy(buf, cmd.Stdin) //nolint:errcheck
 			// docker run's stdin is a pups config
 
 			// web.template.yml is merged with the test config
@@ -161,14 +161,14 @@ var _ = Describe("Build", func() {
 
 		It("Should run docker build with correct arguments", func() {
 			runner := ddocker.DockerBuildCmd{Config: "test"}
-			runner.Run(cli, &ctx)
+			runner.Run(cli, &ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(1))
 			checkBuildCmd(RanCmds[0])
 		})
 
 		It("Should run docker migrate with correct arguments", func() {
 			runner := ddocker.DockerMigrateCmd{Config: "test"}
-			runner.Run(cli, &ctx)
+			runner.Run(cli, &ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(1))
 			checkMigrateCmd(RanCmds[0])
 		})
@@ -180,7 +180,7 @@ var _ = Describe("Build", func() {
 
 			It("Should run docker build with correct namespace and custom flags", func() {
 				runner := ddocker.DockerBuildCmd{Config: "test", Tag: "testtag"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 				Expect(len(RanCmds)).To(Equal(1))
 				checkBuildCmd(RanCmds[0])
 				Expect(RanCmds[0].String()).To(ContainSubstring("testnamespace/test:testtag"))
@@ -188,7 +188,7 @@ var _ = Describe("Build", func() {
 
 			It("Should run docker configure with correct namespace and tags", func() {
 				runner := ddocker.DockerConfigureCmd{Config: "test", SourceTag: "build", TargetTag: "configure"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 				Expect(len(RanCmds)).To(Equal(3))
 
 				Expect(RanCmds[0].String()).To(MatchRegexp(
@@ -206,7 +206,7 @@ var _ = Describe("Build", func() {
 
 			It("Should run docker migrate with correct namespace", func() {
 				runner := ddocker.DockerMigrateCmd{Config: "test"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 				Expect(len(RanCmds)).To(Equal(1))
 				Expect(RanCmds[0].String()).To(ContainSubstring("testnamespace/test "))
 			})
@@ -214,7 +214,7 @@ var _ = Describe("Build", func() {
 
 		It("Should allow skip post deployment migrations", func() {
 			runner := ddocker.DockerMigrateCmd{Config: "test", SkipPostDeploymentMigrations: true}
-			runner.Run(cli, &ctx)
+			runner.Run(cli, &ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(1))
 			cmd := RanCmds[0]
 			Expect(cmd.String()).To(ContainSubstring("docker run"))
@@ -225,14 +225,14 @@ var _ = Describe("Build", func() {
 			Expect(cmd.String()).To(ContainSubstring("--rm"))
 			Expect(cmd.Env).To(ContainElement("DISCOURSE_DB_PASSWORD=SOME_SECRET"))
 			buf := new(strings.Builder)
-			io.Copy(buf, cmd.Stdin)
+			io.Copy(buf, cmd.Stdin) //nolint:errcheck
 			// docker run's stdin is a pups config
 			Expect(buf.String()).To(ContainSubstring("path: /etc/service/nginx/run"))
 		})
 
 		It("Should run docker run followed by docker commit and rm container when configuring", func() {
 			runner := ddocker.DockerConfigureCmd{Config: "test"}
-			runner.Run(cli, &ctx)
+			runner.Run(cli, &ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(3))
 
 			checkConfigureCmd(RanCmds[0])
@@ -242,7 +242,7 @@ var _ = Describe("Build", func() {
 
 		It("Should run all docker commands for full bootstrap", func() {
 			runner := ddocker.DockerBootstrapCmd{Config: "test"}
-			runner.Run(cli, &ctx)
+			runner.Run(cli, &ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(5))
 			checkBuildCmd(RanCmds[0])
 			checkMigrateCmd(RanCmds[1])

--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -161,14 +161,14 @@ var _ = Describe("Build", func() {
 
 		It("Should run docker build with correct arguments", func() {
 			runner := ddocker.DockerBuildCmd{Config: "test"}
-			runner.Run(cli, &ctx) //nolint:errcheck
+			runner.Run(cli, ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(1))
 			checkBuildCmd(RanCmds[0])
 		})
 
 		It("Should run docker migrate with correct arguments", func() {
 			runner := ddocker.DockerMigrateCmd{Config: "test"}
-			runner.Run(cli, &ctx) //nolint:errcheck
+			runner.Run(cli, ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(1))
 			checkMigrateCmd(RanCmds[0])
 		})
@@ -180,7 +180,7 @@ var _ = Describe("Build", func() {
 
 			It("Should run docker build with correct namespace and custom flags", func() {
 				runner := ddocker.DockerBuildCmd{Config: "test", Tag: "testtag"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 				Expect(len(RanCmds)).To(Equal(1))
 				checkBuildCmd(RanCmds[0])
 				Expect(RanCmds[0].String()).To(ContainSubstring("testnamespace/test:testtag"))
@@ -188,7 +188,7 @@ var _ = Describe("Build", func() {
 
 			It("Should run docker configure with correct namespace and tags", func() {
 				runner := ddocker.DockerConfigureCmd{Config: "test", SourceTag: "build", TargetTag: "configure"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 				Expect(len(RanCmds)).To(Equal(3))
 
 				Expect(RanCmds[0].String()).To(MatchRegexp(
@@ -206,7 +206,7 @@ var _ = Describe("Build", func() {
 
 			It("Should run docker migrate with correct namespace", func() {
 				runner := ddocker.DockerMigrateCmd{Config: "test"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 				Expect(len(RanCmds)).To(Equal(1))
 				Expect(RanCmds[0].String()).To(ContainSubstring("testnamespace/test "))
 			})
@@ -214,7 +214,7 @@ var _ = Describe("Build", func() {
 
 		It("Should allow skip post deployment migrations", func() {
 			runner := ddocker.DockerMigrateCmd{Config: "test", SkipPostDeploymentMigrations: true}
-			runner.Run(cli, &ctx) //nolint:errcheck
+			runner.Run(cli, ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(1))
 			cmd := RanCmds[0]
 			Expect(cmd.String()).To(ContainSubstring("docker run"))
@@ -232,7 +232,7 @@ var _ = Describe("Build", func() {
 
 		It("Should run docker run followed by docker commit and rm container when configuring", func() {
 			runner := ddocker.DockerConfigureCmd{Config: "test"}
-			runner.Run(cli, &ctx) //nolint:errcheck
+			runner.Run(cli, ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(3))
 
 			checkConfigureCmd(RanCmds[0])
@@ -242,7 +242,7 @@ var _ = Describe("Build", func() {
 
 		It("Should run all docker commands for full bootstrap", func() {
 			runner := ddocker.DockerBootstrapCmd{Config: "test"}
-			runner.Run(cli, &ctx) //nolint:errcheck
+			runner.Run(cli, ctx) //nolint:errcheck
 			Expect(len(RanCmds)).To(Equal(5))
 			checkBuildCmd(RanCmds[0])
 			checkMigrateCmd(RanCmds[1])

--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Build", func() {
 					"local_discourse/test /bin/bash -c /usr/local/bin/pups --stdin --tags=db,precompile",
 			))
 
-			Expect(cmd.Env).To(Equal([]string{
+			Expect(cmd.Env).To(ContainElements(
 				"DISCOURSE_DB_HOST=data",
 				"DISCOURSE_DB_PASSWORD=SOME_SECRET",
 				"DISCOURSE_DB_PORT=",
@@ -131,7 +131,7 @@ var _ = Describe("Build", func() {
 				"RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=1.5",
 				"UNICORN_SIDEKIQS=1",
 				"UNICORN_WORKERS=3",
-			}))
+			))
 
 			buf := new(strings.Builder)
 			io.Copy(buf, cmd.Stdin)

--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Build", func() {
 		var checkBuildCmd = func(cmd exec.Cmd) {
 			Expect(cmd.String()).To(ContainSubstring("docker build"))
 			Expect(cmd.String()).To(ContainSubstring("--build-arg DISCOURSE_DEVELOPER_EMAILS"))
-			Expect(cmd.Dir).To(Equal(testDir + "/test"))
+			Expect(cmd.Dir).To(Equal(testDir))
 
 			//db password is ignored
 			Expect(cmd.Env).ToNot(ContainElement("DISCOURSE_DB_PASSWORD=SOME_SECRET"))

--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Build", func() {
 			Expect(buf.String()).ToNot(ContainSubstring("SKIP_EMBER_CLI_COMPILE=1"))
 
 			// Ensure we clean up the temp dir after building
-				_, err := os.Stat(testDir)
-				Expect(err).To(MatchError(os.IsNotExist, "IsNotExist"))
+			_, err := os.Stat(testDir)
+			Expect(err).To(MatchError(os.IsNotExist, "IsNotExist"))
 		}
 
 		var checkMigrateCmd = func(cmd exec.Cmd) {

--- a/v2/cli_runtime.go
+++ b/v2/cli_runtime.go
@@ -60,6 +60,8 @@ func (r *StartCmd) Run(cli *Cli, ctx *context.Context) error {
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 			cmd.Cancel = func() error {
+				// MacOS cannot kill a process group using the negative pid.
+				// attempt to stop a container by running docker stop
 				if runtime.GOOS == "darwin" {
 					runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 					stopCmd := exec.CommandContext(runCtx, utils.DockerPath, "stop", r.Config)

--- a/v2/cli_runtime.go
+++ b/v2/cli_runtime.go
@@ -94,7 +94,7 @@ func (r *StartCmd) Run(cli *Cli, ctx *context.Context) error {
 
 	defaultHostname, _ := os.Hostname()
 	defaultHostname = defaultHostname + "-" + r.Config
-	hostname := config.DockerHostname(defaultHostname)
+	hostname := config.GetDockerHostname(defaultHostname)
 
 	restart := true
 	detatch := true
@@ -105,7 +105,7 @@ func (r *StartCmd) Run(cli *Cli, ctx *context.Context) error {
 	}
 
 	extraFlags := strings.Fields(r.DockerArgs)
-	bootCmd := config.BootCommand()
+	bootCmd := config.GetBootCommand()
 
 	runner := docker.DockerRunner{
 		Config:      config,

--- a/v2/cli_runtime.go
+++ b/v2/cli_runtime.go
@@ -248,7 +248,12 @@ func (r *LogsCmd) Run(cli *Cli, ctx context.Context) error {
 		return err
 	}
 
-	fmt.Fprintln(utils.Out, string(output[:])) //nolint:errcheck
+	if _, err = utils.Out.Write(output); err != nil {
+		return err
+	}
+	if _, err = utils.Out.Write([]byte("\n")); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/v2/cli_runtime_test.go
+++ b/v2/cli_runtime_test.go
@@ -78,13 +78,13 @@ var _ = Describe("Runtime", func() {
 		Context("without a running container", func() {
 			It("should run start commands", func() {
 				runner := ddocker.StartCmd{Config: "test"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 				checkStartCmd()
 			})
 
 			It("should not run stop commands", func() {
 				runner := ddocker.StopCmd{Config: "test"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 				checkStopCmdWhenMissing()
 			})
 		})
@@ -98,19 +98,19 @@ var _ = Describe("Runtime", func() {
 
 			It("should not run start commands", func() {
 				runner := ddocker.StartCmd{Config: "test"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 				checkStartCmdWhenStarted()
 			})
 
 			It("should run stop commands", func() {
 				runner := ddocker.StopCmd{Config: "test"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 				checkStopCmd()
 			})
 
 			It("should keep running during commits, and be post-deploy migration aware when using a web only container", func() {
 				runner := ddocker.RebuildCmd{Config: "web_only"}
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 
 				//initial build
 				cmd := GetLastCommand()
@@ -154,7 +154,7 @@ var _ = Describe("Runtime", func() {
 			It("should stop with standalone", func() {
 				runner := ddocker.RebuildCmd{Config: "standalone"}
 
-				runner.Run(cli, &ctx) //nolint:errcheck
+				runner.Run(cli, ctx) //nolint:errcheck
 
 				//initial build
 				cmd := GetLastCommand()

--- a/v2/cli_runtime_test.go
+++ b/v2/cli_runtime_test.go
@@ -35,10 +35,6 @@ var _ = Describe("Runtime", func() {
 		utils.CmdRunner = CreateNewFakeCmdRunner()
 	})
 
-	AfterEach(func() {
-		os.RemoveAll(testDir) //nolint:errcheck
-	})
-
 	Context("When running run commands", func() {
 		var checkStartCmd = func() {
 			Expect(len(RanCmds)).To(Equal(3))
@@ -197,6 +193,10 @@ var _ = Describe("Runtime", func() {
 				cmd = GetLastCommand()
 				Expect(cmd.String()).To(ContainSubstring("docker ps --quiet"))
 				Expect(len(RanCmds)).To(Equal(0))
+
+				// Ensure we clean up the temp dir after building
+				_, err := os.Stat(testDir)
+				Expect(err).To(MatchError(os.IsNotExist, "IsNotExist"))
 			})
 		})
 

--- a/v2/cli_runtime_test.go
+++ b/v2/cli_runtime_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Runtime", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(testDir)
+		os.RemoveAll(testDir) //nolint:errcheck
 	})
 
 	Context("When running run commands", func() {
@@ -82,13 +82,13 @@ var _ = Describe("Runtime", func() {
 		Context("without a running container", func() {
 			It("should run start commands", func() {
 				runner := ddocker.StartCmd{Config: "test"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 				checkStartCmd()
 			})
 
 			It("should not run stop commands", func() {
 				runner := ddocker.StopCmd{Config: "test"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 				checkStopCmdWhenMissing()
 			})
 		})
@@ -102,19 +102,19 @@ var _ = Describe("Runtime", func() {
 
 			It("should not run start commands", func() {
 				runner := ddocker.StartCmd{Config: "test"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 				checkStartCmdWhenStarted()
 			})
 
 			It("should run stop commands", func() {
 				runner := ddocker.StopCmd{Config: "test"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 				checkStopCmd()
 			})
 
 			It("should keep running during commits, and be post-deploy migration aware when using a web only container", func() {
 				runner := ddocker.RebuildCmd{Config: "web_only"}
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 
 				//initial build
 				cmd := GetLastCommand()
@@ -158,7 +158,7 @@ var _ = Describe("Runtime", func() {
 			It("should stop with standalone", func() {
 				runner := ddocker.RebuildCmd{Config: "standalone"}
 
-				runner.Run(cli, &ctx)
+				runner.Run(cli, &ctx) //nolint:errcheck
 
 				//initial build
 				cmd := GetLastCommand()

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -17,30 +17,30 @@ import (
 const defaultBootCommand = "/sbin/boot"
 
 type Config struct {
-	Name            string `yaml:-`
+	Name            string `yaml:"-"`
 	rawYaml         []string
-	Base_Image      string            `yaml:,omitempty`
-	Update_Pups     bool              `yaml:,omitempty`
-	Run_Image       string            `yaml:,omitempty`
-	Boot_Command    string            `yaml:,omitempty`
-	No_Boot_Command bool              `yaml:,omitempty`
-	Docker_Args     string            `yaml:,omitempty`
-	Templates       []string          `yaml:templates,omitempty`
-	Expose          []string          `yaml:expose,omitempty`
-	Env             map[string]string `yaml:env,omitempty`
-	Labels          map[string]string `yaml:labels,omitempty`
+	Base_Image      string            `yaml:",omitempty"`
+	Update_Pups     bool              `yaml:",omitempty"`
+	Run_Image       string            `yaml:",omitempty"`
+	Boot_Command    string            `yaml:",omitempty"`
+	No_Boot_Command bool              `yaml:",omitempty"`
+	Docker_Args     string            `yaml:",omitempty"`
+	Templates       []string          `yaml:"templates,omitempty"`
+	Expose          []string          `yaml:"expose,omitempty"`
+	Env             map[string]string `yaml:"env,omitempty"`
+	Labels          map[string]string `yaml:"labels,omitempty"`
 	Volumes         []struct {
 		Volume struct {
-			Host  string `yaml:host`
-			Guest string `yaml:guest`
-		} `yaml:volume`
-	} `yaml:volumes,omitempty`
+			Host  string `yaml:"host"`
+			Guest string `yaml:"guest"`
+		} `yaml:"volume"`
+	} `yaml:"volumes,omitempty"`
 	Links []struct {
 		Link struct {
-			Name  string `yaml:name`
-			Alias string `yaml:alias`
-		} `yaml:link`
-	} `yaml:links,omitempty`
+			Name  string `yaml:"name"`
+			Alias string `yaml:"alias"`
+		} `yaml:"link"`
+	} `yaml:"links,omitempty"`
 }
 
 func (config *Config) loadTemplate(templateDir string, template string) error {
@@ -122,7 +122,7 @@ func LoadConfig(dir string, configName string, includeTemplates bool, templatesD
 	}
 
 	if config.Base_Image == "" {
-		return nil, errors.New("No base image specified in config! Set base image with `base_image: {imagename}`")
+		return nil, errors.New("no base image specified in config! set base image with `base_image: {imagename}`")
 	}
 
 	return config, nil
@@ -185,7 +185,7 @@ func (config *Config) DockerArgs() []string {
 
 func (config *Config) dockerfileEnvs() string {
 	builder := []string{}
-	for k, _ := range config.Env {
+	for k := range config.Env {
 		builder = append(builder, "ENV "+k+"=${"+k+"}")
 	}
 	slices.Sort(builder)
@@ -194,7 +194,7 @@ func (config *Config) dockerfileEnvs() string {
 
 func (config *Config) dockerfileArgs() string {
 	builder := []string{}
-	for k, _ := range config.Env {
+	for k := range config.Env {
 		builder = append(builder, "ARG "+k)
 	}
 	slices.Sort(builder)

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -65,7 +65,7 @@ func (config *Config) loadTemplate(templateDir string, template string) error {
 
 func LoadConfig(dir string, configName string, includeTemplates bool, templatesDir string) (*Config, error) {
 	config := &Config{
-		Name:         configName,
+		Name:        configName,
 		BootCommand: defaultBootCommand,
 	}
 

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -47,15 +47,15 @@ var _ = Describe("Config", func() {
 	Context("hostname tests", func() {
 		It("replaces hostname", func() {
 			config := config.Config{Env: map[string]string{"DOCKER_USE_HOSTNAME": "true", "DISCOURSE_HOSTNAME": "asdfASDF"}}
-			Expect(config.DockerHostname("")).To(Equal("asdfASDF"))
+			Expect(config.GetDockerHostname("")).To(Equal("asdfASDF"))
 		})
 		It("replaces hostname", func() {
 			config := config.Config{Env: map[string]string{"DOCKER_USE_HOSTNAME": "true", "DISCOURSE_HOSTNAME": "asdf!@#$%^&*()ASDF"}}
-			Expect(config.DockerHostname("")).To(Equal("asdf----------ASDF"))
+			Expect(config.GetDockerHostname("")).To(Equal("asdf----------ASDF"))
 		})
 		It("replaces a default hostnamehostname", func() {
 			config := config.Config{}
-			Expect(config.DockerHostname("asdf!@#")).To(Equal("asdf---"))
+			Expect(config.GetDockerHostname("asdf!@#")).To(Equal("asdf---"))
 		})
 	})
 	It("should error if no base config LoadConfig to load yaml configuration", func() {

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -4,9 +4,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/discourse/launcher/v2/config"
 	"os"
 	"strings"
+
+	"github.com/discourse/launcher/v2/config"
 )
 
 var _ = Describe("Config", func() {

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Config", func() {
 		conf, _ = config.LoadConfig("../test/containers", "test", true, "../test")
 	})
 	AfterEach(func() {
-		os.RemoveAll(testDir)
+		os.RemoveAll(testDir) //nolint:errcheck
 	})
 	It("should be able to run LoadConfig to load yaml configuration", func() {
 		conf, err := config.LoadConfig("../test/containers", "test", true, "../test")
@@ -61,6 +61,6 @@ var _ = Describe("Config", func() {
 	It("should error if no base config LoadConfig to load yaml configuration", func() {
 		_, err := config.LoadConfig("../test/containers", "test-no-base-image", true, "../test")
 		Expect(err).ToNot(BeNil())
-		Expect(err.Error()).To(Equal("No base image specified in config! Set base image with `base_image: {imagename}`"))
+		Expect(err.Error()).To(Equal("no base image specified in config! set base image with `base_image: {imagename}`"))
 	})
 })

--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -38,7 +38,7 @@ func (r *DockerBuilder) Run() error {
 	}
 	cmd.Dir = r.Dir
 	cmd.Env = os.Environ()
-	env := r.Config.EnvArray(false)
+	env := r.Config.GetEnvSlice(false)
 	cmd.Env = append(cmd.Env, env...)
 	cmd.Env = append(cmd.Env, "BUILDKIT_PROGRESS=plain")
 	for k := range r.Config.Env {
@@ -100,7 +100,7 @@ func (r *DockerRunner) Run() error {
 	}
 
 	cmd.Env = os.Environ()
-	env := r.Config.EnvArray(true)
+	env := r.Config.GetEnvSlice(true)
 	cmd.Env = append(cmd.Env, env...)
 	envKeys := make([]string, 0, len(r.Config.Env))
 
@@ -179,7 +179,7 @@ func (r *DockerRunner) Run() error {
 	cmd.Args = append(cmd.Args, "--interactive")
 
 	// Docker args override settings above
-	cmd.Args = append(cmd.Args, r.Config.DockerArgs()...)
+	cmd.Args = append(cmd.Args, r.Config.GetDockerArgs()...)
 	cmd.Args = append(cmd.Args, r.ExtraFlags...)
 
 	if r.Hostname != "" {
@@ -193,7 +193,7 @@ func (r *DockerRunner) Run() error {
 	if len(r.CustomImage) > 0 {
 		cmd.Args = append(cmd.Args, r.CustomImage)
 	} else {
-		cmd.Args = append(cmd.Args, r.Config.RunImage())
+		cmd.Args = append(cmd.Args, r.Config.GetRunImage())
 	}
 
 	cmd.Args = append(cmd.Args, r.Cmd...)
@@ -276,7 +276,7 @@ func (r *DockerPupsRunner) Run() error {
 			"--change",
 			"LABEL org.opencontainers.image.created=\""+time.Now().UTC().Format(time.RFC3339)+"\"",
 			"--change",
-			"CMD [\""+r.Config.BootCommand()+"\"]",
+			"CMD [\""+r.Config.GetBootCommand()+"\"]",
 			r.ContainerId,
 			r.SavedImageName,
 		)

--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -87,6 +87,8 @@ func (r *DockerRunner) Run() error {
 	if !r.Detatch {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		cmd.Cancel = func() error {
+			// MacOS cannot kill a process group using the negative pid.
+			// attempt to stop a container by running docker stop
 			if runtime.GOOS == "darwin" {
 				runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				stopCmd := exec.CommandContext(runCtx, utils.DockerPath, "stop", r.ContainerId)

--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -37,7 +37,11 @@ func (r *DockerBuilder) Run() error {
 		return unix.Kill(-cmd.Process.Pid, unix.SIGINT)
 	}
 	cmd.Dir = r.Dir
-	cmd.Env = r.Config.EnvArray(false)
+	cmd.Env = os.Environ()
+	env := r.Config.EnvArray(false)
+	for _, e := range env {
+		cmd.Env = append(cmd.Env, e)
+	}
 	cmd.Env = append(cmd.Env, "BUILDKIT_PROGRESS=plain")
 	for k, _ := range r.Config.Env {
 		cmd.Args = append(cmd.Args, "--build-arg")
@@ -95,7 +99,11 @@ func (r *DockerRunner) Run() error {
 		}
 	}
 
-	cmd.Env = r.Config.EnvArray(true)
+	cmd.Env = os.Environ()
+	env := r.Config.EnvArray(true)
+	for _, e := range env {
+		cmd.Env = append(cmd.Env, e)
+	}
 	envKeys := make([]string, 0, len(r.Config.Env))
 
 	for envKey := range r.Config.Env {

--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -269,7 +269,7 @@ func (r *DockerPupsRunner) Run(ctx context.Context) error {
 	if len(r.SavedImageName) > 0 {
 		time.Sleep(utils.CommitWait)
 
-		cmd := exec.Command("docker",
+		cmd := exec.Command(utils.DockerPath,
 			"commit",
 			"--change",
 			"LABEL org.opencontainers.image.created=\""+time.Now().UTC().Format(time.RFC3339)+"\"",

--- a/v2/docker/commands_test.go
+++ b/v2/docker/commands_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Commands", func() {
 			})
 			AfterEach(func() {
 				os.Unsetenv("launcher_test") //nolint:errcheck
-				os.RemoveAll(testDir) //nolint:errcheck
+				os.RemoveAll(testDir)        //nolint:errcheck
 			})
 			It("Inherits environment for docker build", func() {
 				runner := docker.DockerBuilder{Config: conf, Ctx: &ctx, Stdin: nil, Dir: testDir, Namespace: "test", ImageTag: "test"}

--- a/v2/docker/commands_test.go
+++ b/v2/docker/commands_test.go
@@ -30,8 +30,8 @@ var _ = Describe("Commands", func() {
 			utils.CmdRunner = CreateNewFakeCmdRunner()
 		})
 		It("Removes unspecified image tags on commit", func() {
-			runner := docker.DockerPupsRunner{Config: conf, ContainerId: "123", Ctx: &ctx, SavedImageName: "local_discourse/test:"}
-			runner.Run() //nolint:errcheck
+			runner := docker.DockerPupsRunner{Config: conf, ContainerId: "123", SavedImageName: "local_discourse/test:"}
+			runner.Run(ctx) //nolint:errcheck
 			cmd := GetLastCommand()
 			Expect(cmd.String()).To(ContainSubstring("docker run"))
 			cmd = GetLastCommand()
@@ -52,14 +52,14 @@ var _ = Describe("Commands", func() {
 				os.RemoveAll(testDir)        //nolint:errcheck
 			})
 			It("Inherits environment for docker build", func() {
-				runner := docker.DockerBuilder{Config: conf, Ctx: &ctx, Stdin: nil, Dir: testDir, Namespace: "test", ImageTag: "test"}
-				runner.Run() //nolint:errcheck
+				runner := docker.DockerBuilder{Config: conf, Stdin: nil, Dir: testDir, Namespace: "test", ImageTag: "test"}
+				runner.Run(ctx) //nolint:errcheck
 				cmd := GetLastCommand()
 				Expect(cmd.Env).To(ContainElement("launcher_test=testval"))
 			})
 			It("Inherits environment for docker run", func() {
-				runner := docker.DockerRunner{Config: conf, Ctx: &ctx, Stdin: nil}
-				runner.Run() //nolint:errcheck
+				runner := docker.DockerRunner{Config: conf, Stdin: nil}
+				runner.Run(ctx) //nolint:errcheck
 				cmd := GetLastCommand()
 				Expect(cmd.Env).To(ContainElement("launcher_test=testval"))
 			})

--- a/v2/docker/commands_test.go
+++ b/v2/docker/commands_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Commands", func() {
 		})
 		It("Removes unspecified image tags on commit", func() {
 			runner := docker.DockerPupsRunner{Config: conf, ContainerId: "123", Ctx: &ctx, SavedImageName: "local_discourse/test:"}
-			runner.Run()
+			runner.Run() //nolint:errcheck
 			cmd := GetLastCommand()
 			Expect(cmd.String()).To(ContainSubstring("docker run"))
 			cmd = GetLastCommand()
@@ -44,22 +44,22 @@ var _ = Describe("Commands", func() {
 		Context("With environment var set", func() {
 			var testDir string
 			BeforeEach(func() {
-				os.Setenv("launcher_test", "testval")
+				os.Setenv("launcher_test", "testval") //nolint:errcheck
 				testDir, _ = os.MkdirTemp("", "ddocker-test")
 			})
 			AfterEach(func() {
-				os.Unsetenv("launcher_test")
-				os.RemoveAll(testDir)
+				os.Unsetenv("launcher_test") //nolint:errcheck
+				os.RemoveAll(testDir) //nolint:errcheck
 			})
 			It("Inherits environment for docker build", func() {
 				runner := docker.DockerBuilder{Config: conf, Ctx: &ctx, Stdin: nil, Dir: testDir, Namespace: "test", ImageTag: "test"}
-				runner.Run()
+				runner.Run() //nolint:errcheck
 				cmd := GetLastCommand()
 				Expect(cmd.Env).To(ContainElement("launcher_test=testval"))
 			})
 			It("Inherits environment for docker run", func() {
 				runner := docker.DockerRunner{Config: conf, Ctx: &ctx, Stdin: nil}
-				runner.Run()
+				runner.Run() //nolint:errcheck
 				cmd := GetLastCommand()
 				Expect(cmd.Env).To(ContainElement("launcher_test=testval"))
 			})

--- a/v2/docker/commands_test.go
+++ b/v2/docker/commands_test.go
@@ -6,12 +6,13 @@ import (
 
 	"bytes"
 	"context"
+	"os"
+	"strings"
+
 	"github.com/discourse/launcher/v2/config"
 	"github.com/discourse/launcher/v2/docker"
 	. "github.com/discourse/launcher/v2/test_utils"
 	"github.com/discourse/launcher/v2/utils"
-	"os"
-	"strings"
 )
 
 var _ = Describe("Commands", func() {

--- a/v2/main.go
+++ b/v2/main.go
@@ -17,7 +17,7 @@ type Cli struct {
 	Version      kong.VersionFlag   `help:"Show version."`
 	ConfDir      string             `default:"./containers" hidden:"" help:"Discourse pups config directory." predictor:"dir"`
 	TemplatesDir string             `default:"." hidden:"" help:"Home project directory containing a templates/ directory which in turn contains pups yaml templates." predictor:"dir"`
-	BuildDir     string             `default:"./tmp" hidden:"" help:"Temporary build folder for building images." predictor:"dir"`
+	BuildDir     string             `default:"" hidden:"" help:"Temporary build folder for building images." predictor:"dir"`
 	Namespace    string             `default:"local_discourse" env:"DISCOURSE_NAMESPACE" help:"image namespace."`
 	BuildCmd     DockerBuildCmd     `cmd:"" name:"build" help:"Build a base image. This command does not need a running database. Saves resulting container."`
 	ConfigureCmd DockerConfigureCmd `cmd:"" name:"configure" help:"Configure and save an image with all dependencies and environment baked in. Updates themes and precompiles all assets. Saves resulting container."`

--- a/v2/main.go
+++ b/v2/main.go
@@ -65,7 +65,7 @@ func main() {
 	go func() {
 		select {
 		case <-sigChan:
-			fmt.Fprintln(utils.Out, "Command interrupted")
+			fmt.Fprintln(utils.Out, "Command interrupted") //nolint:errcheck
 			cancel()
 		case <-done:
 		}
@@ -79,7 +79,7 @@ func main() {
 		if exiterr.ExitCode() == 77 {
 			os.Exit(77)
 		} else if runCtx.Err() != nil {
-			fmt.Fprintln(utils.Out, "Aborted with exit code", exiterr.ExitCode())
+			fmt.Fprintln(utils.Out, "Aborted with exit code", exiterr.ExitCode()) //nolint:errcheck
 		} else {
 			ctx.Fatalf(
 				"run failed with exit code %v\n"+

--- a/v2/main.go
+++ b/v2/main.go
@@ -44,7 +44,7 @@ func main() {
 	// pre parse to get config dir for prediction of conf dir
 	confFiles := utils.FindConfigNames()
 
-	parser := kong.Must(&cli, kong.UsageOnError(), kong.Bind(&runCtx), kong.Vars{"version": utils.Version})
+	parser := kong.Must(&cli, kong.UsageOnError(), kong.Vars{"version": utils.Version})
 
 	// Run kongplete.Complete to handle completion requests
 	kongplete.Complete(parser,
@@ -57,6 +57,7 @@ func main() {
 	parser.FatalIfErrorf(err)
 
 	defer cancel()
+	ctx.BindTo(runCtx, (*context.Context)(nil))
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, unix.SIGTERM)
 	signal.Notify(sigChan, unix.SIGINT)

--- a/v2/main.go
+++ b/v2/main.go
@@ -17,7 +17,7 @@ type Cli struct {
 	Version      kong.VersionFlag   `help:"Show version."`
 	ConfDir      string             `default:"./containers" hidden:"" help:"Discourse pups config directory." predictor:"dir"`
 	TemplatesDir string             `default:"." hidden:"" help:"Home project directory containing a templates/ directory which in turn contains pups yaml templates." predictor:"dir"`
-	BuildDir     string             `default:"" hidden:"" help:"Temporary build folder for building images." predictor:"dir"`
+	BuildDir     string             `default:"" hidden:"" help:"Temporary build directory for building images." predictor:"dir"`
 	Namespace    string             `default:"local_discourse" env:"DISCOURSE_NAMESPACE" help:"image namespace."`
 	BuildCmd     DockerBuildCmd     `cmd:"" name:"build" help:"Build a base image. This command does not need a running database. Saves resulting container."`
 	ConfigureCmd DockerConfigureCmd `cmd:"" name:"configure" help:"Configure and save an image with all dependencies and environment baked in. Updates themes and precompiles all assets. Saves resulting container."`

--- a/v2/main.go
+++ b/v2/main.go
@@ -24,12 +24,12 @@ type Cli struct {
 	MigrateCmd   DockerMigrateCmd   `cmd:"" name:"migrate" help:"Run migration tasks for a site. Running container is temporary and is not saved."`
 	BootstrapCmd DockerBootstrapCmd `cmd:"" name:"bootstrap" help:"Builds, migrates, and configures an image. Resulting image is a fully built and configured Discourse image."`
 
-	DestroyCmd DestroyCmd `cmd:"" alias:"rm" name:"destroy" help:"Shutdown and destroy container."`
+	DestroyCmd DestroyCmd `cmd:"" name:"destroy" aliases:"down,rm" help:"Shutdown and destroy container."`
 	LogsCmd    LogsCmd    `cmd:"" name:"logs" help:"Print logs for container."`
 	CleanupCmd CleanupCmd `cmd:"" name:"cleanup" help:"Cleanup unused containers."`
 	EnterCmd   EnterCmd   `cmd:"" name:"enter" help:"Connects to a shell running in the container."`
 	RunCmd     RunCmd     `cmd:"" name:"run" help:"Runs the specified command in context of a docker container."`
-	StartCmd   StartCmd   `cmd:"" name:"start" help:"Starts container."`
+	StartCmd   StartCmd   `cmd:"" name:"start" aliases:"up" help:"Starts container."`
 	StopCmd    StopCmd    `cmd:"" name:"stop" help:"Stops container."`
 	RestartCmd RestartCmd `cmd:"" name:"restart" help:"Stops then starts container."`
 	RebuildCmd RebuildCmd `cmd:"" name:"rebuild" help:"Builds new image, then destroys old container, and starts new container."`

--- a/v2/test_utils/utils.go
+++ b/v2/test_utils/utils.go
@@ -1,8 +1,9 @@
 package test_utils
 
 import (
-	"github.com/discourse/launcher/v2/utils"
 	"os/exec"
+
+	"github.com/discourse/launcher/v2/utils"
 )
 
 var RanCmds []exec.Cmd

--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const Version = "v2.0.5"
+const Version = "v2.0.6"
 
 const DefaultNamespace = "local_discourse"
 

--- a/v2/utils/find_config.go
+++ b/v2/utils/find_config.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bytes"
 	"flag"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -28,12 +27,12 @@ func FindConfigNames() []string {
 	//squelch helptext
 	flags.SetOutput(&bytes.Buffer{})
 	confDirArg := flags.String("conf-dir", "./containers", "conf dir")
-	flags.Parse(flagLine)
+	flags.Parse(flagLine) //nolint:errcheck
 
 	// search in the current conf dir for any files
 	confDir := strings.TrimRight(*confDirArg, "/") + "/"
 	confFiles := []string{}
-	files, err := ioutil.ReadDir(confDir)
+	files, err := os.ReadDir(confDir)
 	if err == nil {
 		for _, file := range files {
 			if !file.IsDir() {

--- a/v2/utils/find_config_test.go
+++ b/v2/utils/find_config_test.go
@@ -4,8 +4,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/discourse/launcher/v2/utils"
 	"os"
+
+	"github.com/discourse/launcher/v2/utils"
 )
 
 var _ = Describe("FindConfig", func() {

--- a/v2/utils/find_config_test.go
+++ b/v2/utils/find_config_test.go
@@ -11,29 +11,29 @@ import (
 var _ = Describe("FindConfig", func() {
 
 	It("Parses and returns yml or yaml files", func() {
-		os.Setenv("COMP_LINE", "launcher build --conf-dir ../test/containers")
+		os.Setenv("COMP_LINE", "launcher build --conf-dir ../test/containers") //nolint:errcheck
 		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
 	})
 
 	It("Parses and returns yml or yaml files with trailing slash", func() {
-		os.Setenv("COMP_LINE", "launcher build --conf-dir ../test/containers/")
+		os.Setenv("COMP_LINE", "launcher build --conf-dir ../test/containers/") //nolint:errcheck
 		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
 	})
 
 	It("Parses and returns yml or yaml files on equals", func() {
-		os.Setenv("COMP_LINE", "launcher --conf-dir=../test/containers other args")
+		os.Setenv("COMP_LINE", "launcher --conf-dir=../test/containers other args") //nolint:errcheck
 		Expect(utils.FindConfigNames()).To(ContainElements("test", "test2"))
 	})
 
 	It("doesn't error when dir does not exist when set", func() {
-		os.Setenv("COMP_LINE", "launcher --conf-dir=./does-not-exist")
+		os.Setenv("COMP_LINE", "launcher --conf-dir=./does-not-exist") //nolint:errcheck
 		Expect(utils.FindConfigNames()).To(BeEmpty())
 	})
 
 	It("doesn't error when dir does not exist", func() {
 		//by default it look is in ./containers directory, which does not exist
 		// in this directory
-		os.Setenv("COMP_LINE", "launcher")
+		os.Setenv("COMP_LINE", "launcher") //nolint:errcheck
 		Expect(utils.FindConfigNames()).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
Append extra env in docker build/run calls to the current process' environment, rather than replace it wholesale.