### PR TITLE
Multistage builds

### DIFF
--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -20,7 +20,7 @@ import (
  */
 type DockerBuildCmd struct {
 	BakeEnv    bool     `short:"e" help:"Bake in the configured environment to image after build."`
-	BuildSlim  bool     `help:"Build a minimal image from a multistage build"`
+	BuildSlim  bool     `hidden:"" help:"Build a minimal image from a multistage build"`
 	Tag        string   `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
 	Config     string   `arg:"" name:"config" help:"configuration" predictor:"config" passthrough:""`
 	ExtraFlags []string `arg:"" optional:"" name:"docker-build-flags" help:"Extra build flags for docker build"`

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -19,11 +19,11 @@ import (
  * bootstrap
  */
 type DockerBuildCmd struct {
-	BakeEnv      bool     `short:"e" help:"Bake in the configured environment to image after build."`
-	Slim         bool     `help:"Build a slim image"`
-	Tag          string   `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
-	Config       string   `arg:"" name:"config" help:"configuration" predictor:"config" passthrough:""`
-	ExtraFlags   []string `arg:"" optional:"" name:"docker-build-flags" help:"Extra build flags for docker build"`
+	BakeEnv    bool     `short:"e" help:"Bake in the configured environment to image after build."`
+	BuildSlim  bool     `help:"Build a minimal image from a multistage build"`
+	Tag        string   `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
+	Config     string   `arg:"" name:"config" help:"configuration" predictor:"config" passthrough:""`
+	ExtraFlags []string `arg:"" optional:"" name:"docker-build-flags" help:"Extra build flags for docker build"`
 }
 
 func (r *DockerBuildCmd) Run(cli *Cli, ctx context.Context) error {
@@ -45,11 +45,11 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx context.Context) error {
 	}
 
 	builder := docker.DockerBuilder{
-		Config:       config,
-		Stdin:        strings.NewReader(config.Dockerfile(r.BakeEnv, configFile)),
-		Dir:          dir,
-		ImageTag:     r.Tag,
-		ExtraFlags:   r.ExtraFlags,
+		Config:     config,
+		Stdin:      strings.NewReader(config.Dockerfile(r.BakeEnv, r.BuildSlim, configFile)),
+		Dir:        dir,
+		ImageTag:   r.Tag,
+		ExtraFlags: r.ExtraFlags,
 	}
 	if err := builder.Run(ctx); err != nil {
 		if configErr := config.ValidateConfig(err); configErr != nil {
@@ -143,8 +143,8 @@ func (r *DockerMigrateCmd) Run(cli *Cli, ctx context.Context) error {
 }
 
 type DockerBootstrapCmd struct {
-	Config       string `arg:"" name:"config" help:"config" predictor:"config"`
-	Tag          string `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
+	Config string `arg:"" name:"config" help:"config" predictor:"config"`
+	Tag    string `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
 }
 
 func (r *DockerBootstrapCmd) Run(cli *Cli, ctx context.Context) error {

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -21,6 +21,7 @@ import (
 type DockerBuildCmd struct {
 	BakeEnv      bool     `short:"e" help:"Bake in the configured environment to image after build."`
 	MountVolumes bool     `short:"v" hidden:"" help:"mount volume at build time. No data to the host is written by this."`
+	Slim         bool     `help:"Build a slim image"`
 	Tag          string   `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
 	Config       string   `arg:"" name:"config" help:"configuration" predictor:"config" passthrough:""`
 	ExtraFlags   []string `arg:"" optional:"" name:"docker-build-flags" help:"Extra build flags for docker build"`
@@ -44,10 +45,9 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx context.Context) error {
 		return err
 	}
 
-	pupsArgs := "--skip-tags=precompile,migrate,db"
 	builder := docker.DockerBuilder{
 		Config:       config,
-		Stdin:        strings.NewReader(config.Dockerfile(pupsArgs, r.BakeEnv, r.MountVolumes, configFile)),
+		Stdin:        strings.NewReader(config.Dockerfile(r.BakeEnv, r.MountVolumes, configFile)),
 		Dir:          dir,
 		ImageTag:     r.Tag,
 		ExtraFlags:   r.ExtraFlags,

--- a/v2/cli_build.go
+++ b/v2/cli_build.go
@@ -20,7 +20,6 @@ import (
  */
 type DockerBuildCmd struct {
 	BakeEnv      bool     `short:"e" help:"Bake in the configured environment to image after build."`
-	MountVolumes bool     `short:"v" hidden:"" help:"mount volume at build time. No data to the host is written by this."`
 	Slim         bool     `help:"Build a slim image"`
 	Tag          string   `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
 	Config       string   `arg:"" name:"config" help:"configuration" predictor:"config" passthrough:""`
@@ -47,11 +46,10 @@ func (r *DockerBuildCmd) Run(cli *Cli, ctx context.Context) error {
 
 	builder := docker.DockerBuilder{
 		Config:       config,
-		Stdin:        strings.NewReader(config.Dockerfile(r.BakeEnv, r.MountVolumes, configFile)),
+		Stdin:        strings.NewReader(config.Dockerfile(r.BakeEnv, configFile)),
 		Dir:          dir,
 		ImageTag:     r.Tag,
 		ExtraFlags:   r.ExtraFlags,
-		MountVolumes: r.MountVolumes,
 	}
 	if err := builder.Run(ctx); err != nil {
 		if configErr := config.ValidateConfig(err); configErr != nil {
@@ -147,7 +145,6 @@ func (r *DockerMigrateCmd) Run(cli *Cli, ctx context.Context) error {
 type DockerBootstrapCmd struct {
 	Config       string `arg:"" name:"config" help:"config" predictor:"config"`
 	Tag          string `short:"t" help:"Resulting image tag. Defaults to 'local_discourse/{config}'"`
-	MountVolumes bool   `short:"v" hidden:"" help:"mount volumes at build time. No data to the host is written by this."`
 }
 
 func (r *DockerBootstrapCmd) Run(cli *Cli, ctx context.Context) error {
@@ -155,7 +152,7 @@ func (r *DockerBootstrapCmd) Run(cli *Cli, ctx context.Context) error {
 	if len(r.Tag) > 0 {
 		tag = r.Tag
 	}
-	buildStep := DockerBuildCmd{Config: r.Config, BakeEnv: false, MountVolumes: r.MountVolumes, Tag: tag}
+	buildStep := DockerBuildCmd{Config: r.Config, BakeEnv: false, Tag: tag}
 	migrateStep := DockerMigrateCmd{Config: r.Config, Tag: tag}
 	configureStep := DockerConfigureCmd{Config: r.Config, SourceTag: tag, TargetTag: tag}
 	if err := buildStep.Run(cli, ctx); err != nil {

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -215,7 +215,7 @@ func (config *Config) Dockerfile(bakeEnv bool, mountVolumes bool, configFile str
 	builder.WriteString(config.dockerfileExpose() + "\n")
 	builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
 	// copy full build
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules /var/www/discourse/ /var/www/discourse\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules --exclude=**/libv8_monolith.a /var/www/discourse/ /var/www/discourse\n")
 	// copy pnpm lock, used for calculating asset processor
 	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/.pnpm/lock.yaml /var/www/discourse/node_modules/.pnpm/lock.yaml\n")
 	// copy cached asset processor

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -192,7 +192,7 @@ func (config *Config) Dockerfile(bakeEnv bool, buildSlim bool, configFile string
 		builder.WriteString("FROM discourse-full AS discourse-builder\n")
 		builder.WriteString(config.dockerfileArgs() + "\n")
 		// Cache asset processor
-		builder.WriteString(`RUN su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rails r "AssetProcessor.ember_version"'`)
+		builder.WriteString("RUN su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rails r \"AssetProcessor.ember_version\"'\n")
 		// Cache discourse versions
 		builder.WriteString("RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\\\n")
 		builder.WriteString("FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match \"v[0-9]*\" 2> /dev/null) &&\\\n")

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -191,6 +191,9 @@ func (config *Config) Dockerfile(bakeEnv bool, buildSlim bool, configFile string
 		builder.WriteString("\n")
 		builder.WriteString("FROM discourse-full AS discourse-builder\n")
 		builder.WriteString(config.dockerfileArgs() + "\n")
+		// Cache asset processor
+		builder.WriteString(`RUN su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rails r "AssetProcessor.ember_version"'`)
+		// Cache discourse versions
 		builder.WriteString("RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\\\n")
 		builder.WriteString("FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match \"v[0-9]*\" 2> /dev/null) &&\\\n")
 		builder.WriteString("GIT_BRANCH=$(sudo -u discourse git -C /var/www/discourse branch --show-current) &&\\\n")

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -191,8 +191,6 @@ func (config *Config) Dockerfile(bakeEnv bool, buildSlim bool, configFile string
 		builder.WriteString("\n")
 		builder.WriteString("FROM discourse-full AS discourse-builder\n")
 		builder.WriteString(config.dockerfileArgs() + "\n")
-		// Cache asset processor
-		builder.WriteString("RUN su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rails r \"AssetProcessor.ember_version\"'\n")
 		// Cache discourse versions
 		builder.WriteString("RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\\\n")
 		builder.WriteString("FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match \"v[0-9]*\" 2> /dev/null) &&\\\n")

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -163,7 +163,7 @@ func (config *Config) Yaml() string {
 	return strings.Join(config.rawYaml, "_FILE_SEPERATOR_")
 }
 
-func (config *Config) Dockerfile(bakeEnv bool, configFile string) string {
+func (config *Config) Dockerfile(bakeEnv bool, buildSlim bool, configFile string) string {
 	if configFile == "" {
 		configFile = "config.yaml"
 	}
@@ -185,46 +185,48 @@ func (config *Config) Dockerfile(bakeEnv bool, configFile string) string {
 	builder.WriteString(
 		"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin " +
 			"&& rm /temp-config.yaml\n")
-
 	builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]\n")
-	builder.WriteString("\n")
-	builder.WriteString("FROM discourse-full AS discourse-builder\n")
-	builder.WriteString(config.dockerfileArgs() + "\n")
-	builder.WriteString("RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\\\n")
-	builder.WriteString("FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match \"v[0-9]*\" 2> /dev/null) &&\\\n")
-	builder.WriteString("GIT_BRANCH=$(sudo -u discourse git -C /var/www/discourse branch --show-current) &&\\\n")
-	builder.WriteString("printf '{\"git_version\":\"%s\", \"full_version\":\"%s\",\"git_branch\":\"%s\"}' \"${GIT_HASH}\" \"${FULL_VERSION}\" \"${GIT_BRANCH}\" > /var/www/discourse/config/git-utils-overrides.json\n")
 
-	builder.WriteString("\n")
-	builder.WriteString("FROM ${dockerfile_from_image_slim} AS discourse-slim\n")
-	builder.WriteString(config.dockerfileArgs() + "\n")
-	if bakeEnv {
-		builder.WriteString(config.dockerfileEnvs() + "\n")
-	} else {
-		builder.WriteString(config.dockerfileDefaultEnvs() + "\n")
+	if buildSlim {
+		builder.WriteString("\n")
+		builder.WriteString("FROM discourse-full AS discourse-builder\n")
+		builder.WriteString(config.dockerfileArgs() + "\n")
+		builder.WriteString("RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\\\n")
+		builder.WriteString("FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match \"v[0-9]*\" 2> /dev/null) &&\\\n")
+		builder.WriteString("GIT_BRANCH=$(sudo -u discourse git -C /var/www/discourse branch --show-current) &&\\\n")
+		builder.WriteString("printf '{\"git_version\":\"%s\", \"full_version\":\"%s\",\"git_branch\":\"%s\"}' \"${GIT_HASH}\" \"${FULL_VERSION}\" \"${GIT_BRANCH}\" > /var/www/discourse/config/git-utils-overrides.json\n")
+
+		builder.WriteString("\n")
+		builder.WriteString("FROM ${dockerfile_from_image_slim} AS discourse-slim\n")
+		builder.WriteString(config.dockerfileArgs() + "\n")
+		if bakeEnv {
+			builder.WriteString(config.dockerfileEnvs() + "\n")
+		} else {
+			builder.WriteString(config.dockerfileDefaultEnvs() + "\n")
+		}
+		builder.WriteString(config.dockerfileExpose() + "\n")
+		builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
+		// copy full build
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules --exclude=**/libv8_monolith.a /var/www/discourse/ /var/www/discourse\n")
+		// copy pnpm lock, used for calculating asset processor
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/.pnpm/lock.yaml /var/www/discourse/node_modules/.pnpm/lock.yaml\n")
+		// copy cached asset processor
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/tmp/asset-processor /var/www/discourse/tmp/asset-processor\n")
+		//copy runtime-dependent node_modules
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js\n")
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js\n")
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js\n")
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment/moment.js /var/www/discourse/frontend/discourse/node_modules/moment/moment.js\n")
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment-timezone/builds/moment-timezone-with-data.js /var/www/discourse/frontend/discourse/node_modules/moment-timezone/builds/moment-timezone-with-data.js\n")
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/ /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/\n")
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales\n")
+		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment/locale /var/www/discourse/frontend/discourse/node_modules/moment/locale\n")
+		builder.WriteString("RUN ")
+		builder.WriteString(
+			"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=build,precompile,migrate,db --stdin " +
+				"&& rm /temp-config.yaml\n")
+		builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]\n")
 	}
-	builder.WriteString(config.dockerfileExpose() + "\n")
-	builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
-	// copy full build
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules --exclude=**/libv8_monolith.a /var/www/discourse/ /var/www/discourse\n")
-	// copy pnpm lock, used for calculating asset processor
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/.pnpm/lock.yaml /var/www/discourse/node_modules/.pnpm/lock.yaml\n")
-	// copy cached asset processor
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/tmp/asset-processor /var/www/discourse/tmp/asset-processor\n")
-	//copy runtime-dependent node_modules
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js\n")
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js\n")
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js\n")
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment/moment.js /var/www/discourse/frontend/discourse/node_modules/moment/moment.js\n")
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment-timezone/builds/moment-timezone-with-data.js /var/www/discourse/frontend/discourse/node_modules/moment-timezone/builds/moment-timezone-with-data.js\n")
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/ /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/\n")
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales\n")
-	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment/locale /var/www/discourse/frontend/discourse/node_modules/moment/locale\n")
-	builder.WriteString("RUN ")
-	builder.WriteString(
-		"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=build,precompile,migrate,db --stdin " +
-			"&& rm /temp-config.yaml\n")
-	builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]\n")
 
 	return builder.String()
 }

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 
 	"dario.cat/mergo"
@@ -164,7 +163,7 @@ func (config *Config) Yaml() string {
 	return strings.Join(config.rawYaml, "_FILE_SEPERATOR_")
 }
 
-func (config *Config) Dockerfile(bakeEnv bool, mountVolumes bool, configFile string) string {
+func (config *Config) Dockerfile(bakeEnv bool, configFile string) string {
 	if configFile == "" {
 		configFile = "config.yaml"
 	}
@@ -183,14 +182,6 @@ func (config *Config) Dockerfile(bakeEnv bool, mountVolumes bool, configFile str
 
 	builder.WriteString("RUN ")
 
-	// add mounts if any volumes exist and make it available on build time.
-	// they won't be modifiable at build time, but this allows any cached data
-	// to be made available to the builder
-	if mountVolumes {
-		for i, v := range config.Volumes {
-			builder.WriteString("--mount=type=bind,from=volume_" + strconv.Itoa(i) + ",source=/,target=" + v.Volume.Guest + ",rw=true ")
-		}
-	}
 	builder.WriteString(
 		"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin " +
 			"&& rm /temp-config.yaml\n")

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Name          string `yaml:"-"`
 	rawYaml       []string
 	BaseImage     string            `yaml:"base_image,omitempty"`
+	BaseImageSlim string            `yaml:"base_image_slim,omitempty"`
 	UpdatePups    bool              `yaml:"update_pups,omitempty"`
 	RunImage      string            `yaml:"run_image,omitempty"`
 	BootCommand   string            `yaml:"boot_command,omitempty"`
@@ -140,6 +141,10 @@ func LoadConfig(dir string, configName string, includeTemplates bool, templatesD
 		return nil, errors.New("no base image specified in config, set base image with `base_image: {imagename}`")
 	}
 
+	if config.BaseImageSlim == "" {
+		config.BaseImageSlim = config.BaseImage
+	}
+
 	return config, nil
 }
 
@@ -159,13 +164,14 @@ func (config *Config) Yaml() string {
 	return strings.Join(config.rawYaml, "_FILE_SEPERATOR_")
 }
 
-func (config *Config) Dockerfile(pupsArgs string, bakeEnv bool, mountVolumes bool, configFile string) string {
+func (config *Config) Dockerfile(bakeEnv bool, mountVolumes bool, configFile string) string {
 	if configFile == "" {
 		configFile = "config.yaml"
 	}
 	builder := strings.Builder{}
 	builder.WriteString("ARG dockerfile_from_image=" + config.BaseImage + "\n")
-	builder.WriteString("FROM ${dockerfile_from_image}\n")
+	builder.WriteString("ARG dockerfile_from_image_slim=" + config.BaseImageSlim + "\n")
+	builder.WriteString("FROM ${dockerfile_from_image} AS discourse-full\n")
 	builder.WriteString(config.dockerfileArgs() + "\n")
 	if bakeEnv {
 		builder.WriteString(config.dockerfileEnvs() + "\n")
@@ -186,9 +192,45 @@ func (config *Config) Dockerfile(pupsArgs string, bakeEnv bool, mountVolumes boo
 		}
 	}
 	builder.WriteString(
-		"cat /temp-config.yaml | /usr/local/bin/pups " + pupsArgs + " --stdin " +
+		"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin " +
 			"&& rm /temp-config.yaml\n")
-	builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]")
+
+	builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]\n")
+	builder.WriteString("\n")
+	builder.WriteString("FROM discourse-full AS discourse-builder\n")
+	builder.WriteString(config.dockerfileArgs() + "\n")
+	builder.WriteString("RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\\\n")
+	builder.WriteString("FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match \"v[0-9]*\" 2> /dev/null) &&\\\n")
+	builder.WriteString("GIT_BRANCH=$(sudo -u discourse git -C /var/www/discourse branch --show-current) &&\\\n")
+	builder.WriteString("printf '{\"git_version\":\"%s\", \"full_version\":\"%s\",\"git_branch\":\"%s\"}' \"${GIT_HASH}\" \"${FULL_VERSION}\" \"${GIT_BRANCH}\" > /var/www/discourse/config/git-utils-overrides.json\n")
+
+	builder.WriteString("\n")
+	builder.WriteString("FROM ${dockerfile_from_image_slim} AS discourse-slim\n")
+	builder.WriteString(config.dockerfileArgs() + "\n")
+	if bakeEnv {
+		builder.WriteString(config.dockerfileEnvs() + "\n")
+	} else {
+		builder.WriteString(config.dockerfileDefaultEnvs() + "\n")
+	}
+	builder.WriteString(config.dockerfileExpose() + "\n")
+	builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules /var/www/discourse/ /var/www/discourse\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/.pnpm/lock.yaml /var/www/discourse/node_modules/.pnpm/lock.yaml\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/tmp/asset-processor /var/www/discourse/tmp/asset-processor\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment/moment.js /var/www/discourse/frontend/discourse/node_modules/moment/moment.js\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment-timezone/builds/moment-timezone-with-data.js /var/www/discourse/frontend/discourse/node_modules/moment-timezone/builds/moment-timezone-with-data.js\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/ /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales\n")
+	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment/locale /var/www/discourse/frontend/discourse/node_modules/moment/locale\n")
+	builder.WriteString("RUN ")
+	builder.WriteString(
+		"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=build,precompile,migrate,db --stdin " +
+			"&& rm /temp-config.yaml\n")
+	builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]\n")
+
 	return builder.String()
 }
 

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -214,9 +214,13 @@ func (config *Config) Dockerfile(bakeEnv bool, mountVolumes bool, configFile str
 	}
 	builder.WriteString(config.dockerfileExpose() + "\n")
 	builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
+	// copy full build
 	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules /var/www/discourse/ /var/www/discourse\n")
+	// copy pnpm lock, used for calculating asset processor
 	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/.pnpm/lock.yaml /var/www/discourse/node_modules/.pnpm/lock.yaml\n")
+	// copy cached asset processor
 	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/tmp/asset-processor /var/www/discourse/tmp/asset-processor\n")
+	//copy runtime-dependent node_modules
 	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js /var/www/discourse/frontend/discourse/node_modules/loader.js/dist/loader/loader.js\n")
 	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/markdown-it/dist/markdown-it.js\n")
 	builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js /var/www/discourse/frontend/discourse-markdown-it/node_modules/xss/dist/xss.js\n")

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Config", func() {
 	})
 
 	It("can convert pups config to dockerfile format and bake in default env", func() {
-		dockerfile := conf.Dockerfile(false, false, "config.yaml")
+		dockerfile := conf.Dockerfile(false, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
 ARG LANG
 ARG LANGUAGE
@@ -68,7 +68,7 @@ CMD ["/sbin/boot"]`))
 	})
 
 	It("can generate a dockerfile with all env baked into the image", func() {
-		dockerfile := conf.Dockerfile(true, false, "config.yaml")
+		dockerfile := conf.Dockerfile(true, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
 ARG LANG
 ARG LANGUAGE
@@ -97,34 +97,6 @@ EXPOSE 80
 EXPOSE 90
 COPY config.yaml /temp-config.yaml
 RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
-CMD ["/sbin/boot"]`))
-	})
-
-	It("can generate a dockerfile that includes volume mounts", func() {
-		dockerfile := conf.Dockerfile(false, true, "config.yaml")
-		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
-ARG LANG
-ARG LANGUAGE
-ARG LC_ALL
-ARG MULTI
-ARG RAILS_ENV
-ARG REPLACED
-ARG RUBY_GC_HEAP_GROWTH_MAX_SLOTS
-ARG RUBY_GC_HEAP_INIT_SLOTS
-ARG RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
-ARG UNICORN_SIDEKIQS
-ARG UNICORN_WORKERS
-ENV RAILS_ENV=${RAILS_ENV}
-ENV RUBY_GC_HEAP_GROWTH_MAX_SLOTS=${RUBY_GC_HEAP_GROWTH_MAX_SLOTS}
-ENV RUBY_GC_HEAP_INIT_SLOTS=${RUBY_GC_HEAP_INIT_SLOTS}
-ENV RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=${RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR}
-ENV UNICORN_SIDEKIQS=${UNICORN_SIDEKIQS}
-ENV UNICORN_WORKERS=${UNICORN_WORKERS}
-EXPOSE 443
-EXPOSE 80
-EXPOSE 90
-COPY config.yaml /temp-config.yaml
-RUN --mount=type=bind,from=volume_0,source=/,target=/shared,rw=true --mount=type=bind,from=volume_1,source=/,target=/var/log,rw=true cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
 	})
 

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Config", func() {
 
 	It("can convert pups config to dockerfile format and bake in default env", func() {
 		dockerfile := conf.Dockerfile(false, false, "config.yaml")
-		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
+		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
 ARG LANG
 ARG LANGUAGE
 ARG LC_ALL
@@ -63,13 +63,13 @@ EXPOSE 443
 EXPOSE 80
 EXPOSE 90
 COPY config.yaml /temp-config.yaml
-RUN cat /temp-config.yaml | /usr/local/bin/pups  --stdin && rm /temp-config.yaml
+RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
 	})
 
 	It("can generate a dockerfile with all env baked into the image", func() {
 		dockerfile := conf.Dockerfile(true, false, "config.yaml")
-		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
+		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
 ARG LANG
 ARG LANGUAGE
 ARG LC_ALL
@@ -96,13 +96,13 @@ EXPOSE 443
 EXPOSE 80
 EXPOSE 90
 COPY config.yaml /temp-config.yaml
-RUN cat /temp-config.yaml | /usr/local/bin/pups  --stdin && rm /temp-config.yaml
+RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
 	})
 
 	It("can generate a dockerfile that includes volume mounts", func() {
 		dockerfile := conf.Dockerfile(false, true, "config.yaml")
-		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
+		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
 ARG LANG
 ARG LANGUAGE
 ARG LC_ALL
@@ -124,7 +124,7 @@ EXPOSE 443
 EXPOSE 80
 EXPOSE 90
 COPY config.yaml /temp-config.yaml
-RUN --mount=type=bind,from=volume_0,source=/,target=/shared,rw=true --mount=type=bind,from=volume_1,source=/,target=/var/log,rw=true cat /temp-config.yaml | /usr/local/bin/pups  --stdin && rm /temp-config.yaml
+RUN --mount=type=bind,from=volume_0,source=/,target=/shared,rw=true --mount=type=bind,from=volume_1,source=/,target=/var/log,rw=true cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
 	})
 

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -65,6 +65,8 @@ EXPOSE 90
 COPY config.yaml /temp-config.yaml
 RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
+
+		Expect(dockerfile).ToNot(ContainSubstring(`discourse-slim`))
 	})
 
 	It("can generate a dockerfile with all env baked into the image", func() {
@@ -98,6 +100,76 @@ EXPOSE 90
 COPY config.yaml /temp-config.yaml
 RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
+		Expect(dockerfile).ToNot(ContainSubstring(`discourse-slim`))
+	})
+
+	It("can generate configuration for a slim image from a multistage build", func() {
+		dockerfile := conf.Dockerfile(false, true, "config.yaml")
+		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
+ARG LANG
+ARG LANGUAGE
+ARG LC_ALL
+ARG MULTI
+ARG RAILS_ENV
+ARG REPLACED
+ARG RUBY_GC_HEAP_GROWTH_MAX_SLOTS
+ARG RUBY_GC_HEAP_INIT_SLOTS
+ARG RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
+ARG UNICORN_SIDEKIQS
+ARG UNICORN_WORKERS
+ENV RAILS_ENV=${RAILS_ENV}
+ENV RUBY_GC_HEAP_GROWTH_MAX_SLOTS=${RUBY_GC_HEAP_GROWTH_MAX_SLOTS}
+ENV RUBY_GC_HEAP_INIT_SLOTS=${RUBY_GC_HEAP_INIT_SLOTS}
+ENV RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=${RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR}
+ENV UNICORN_SIDEKIQS=${UNICORN_SIDEKIQS}
+ENV UNICORN_WORKERS=${UNICORN_WORKERS}
+EXPOSE 443
+EXPOSE 80
+EXPOSE 90
+COPY config.yaml /temp-config.yaml
+RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
+CMD ["/sbin/boot"]
+
+FROM discourse-full AS discourse-builder
+ARG LANG
+ARG LANGUAGE
+ARG LC_ALL
+ARG MULTI
+ARG RAILS_ENV
+ARG REPLACED
+ARG RUBY_GC_HEAP_GROWTH_MAX_SLOTS
+ARG RUBY_GC_HEAP_INIT_SLOTS
+ARG RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
+ARG UNICORN_SIDEKIQS
+ARG UNICORN_WORKERS
+RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\
+FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match "v[0-9]*" 2> /dev/null) &&\
+GIT_BRANCH=$(sudo -u discourse git -C /var/www/discourse branch --show-current) &&\
+printf '{"git_version":"%s", "full_version":"%s","git_branch":"%s"}' "${GIT_HASH}" "${FULL_VERSION}" "${GIT_BRANCH}" > /var/www/discourse/config/git-utils-overrides.json
+
+FROM ${dockerfile_from_image_slim} AS discourse-slim
+ARG LANG
+ARG LANGUAGE
+ARG LC_ALL
+ARG MULTI
+ARG RAILS_ENV
+ARG REPLACED
+ARG RUBY_GC_HEAP_GROWTH_MAX_SLOTS
+ARG RUBY_GC_HEAP_INIT_SLOTS
+ARG RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
+ARG UNICORN_SIDEKIQS
+ARG UNICORN_WORKERS
+ENV RAILS_ENV=${RAILS_ENV}
+ENV RUBY_GC_HEAP_GROWTH_MAX_SLOTS=${RUBY_GC_HEAP_GROWTH_MAX_SLOTS}
+ENV RUBY_GC_HEAP_INIT_SLOTS=${RUBY_GC_HEAP_INIT_SLOTS}
+ENV RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=${RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR}
+ENV UNICORN_SIDEKIQS=${UNICORN_SIDEKIQS}
+ENV UNICORN_WORKERS=${UNICORN_WORKERS}
+EXPOSE 443
+EXPOSE 80
+EXPOSE 90
+COPY config.yaml /temp-config.yaml
+COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules --exclude=**/libv8_monolith.a /var/www/discourse/ /var/www/discourse`))
 	})
 
 	Context("hostname tests", func() {

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -144,7 +144,6 @@ ARG RUBY_GC_HEAP_INIT_SLOTS
 ARG RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
 ARG UNICORN_SIDEKIQS
 ARG UNICORN_WORKERS
-RUN su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rails r "AssetProcessor.ember_version"'
 RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\
 FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match "v[0-9]*" 2> /dev/null) &&\
 GIT_BRANCH=$(sudo -u discourse git -C /var/www/discourse branch --show-current) &&\

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Config", func() {
 	})
 
 	It("can convert pups config to dockerfile format and bake in default env", func() {
-		dockerfile := conf.Dockerfile(false, "config.yaml")
+		dockerfile := conf.Dockerfile(false, false, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
 ARG LANG
 ARG LANGUAGE
@@ -68,7 +68,7 @@ CMD ["/sbin/boot"]`))
 	})
 
 	It("can generate a dockerfile with all env baked into the image", func() {
-		dockerfile := conf.Dockerfile(true, "config.yaml")
+		dockerfile := conf.Dockerfile(true, false, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full
 ARG LANG
 ARG LANGUAGE

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -144,6 +144,7 @@ ARG RUBY_GC_HEAP_INIT_SLOTS
 ARG RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR
 ARG UNICORN_SIDEKIQS
 ARG UNICORN_WORKERS
+RUN su discourse -c 'SKIP_DB_AND_REDIS=1 bundle exec rails r "AssetProcessor.ember_version"'
 RUN GIT_HASH=$(sudo -u discourse git -C /var/www/discourse rev-parse HEAD) &&\
 FULL_VERSION=$(sudo -u discourse git -C /var/www/discourse describe --dirty --match "v[0-9]*" 2> /dev/null) &&\
 GIT_BRANCH=$(sudo -u discourse git -C /var/www/discourse branch --show-current) &&\

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -66,6 +66,7 @@ COPY config.yaml /temp-config.yaml
 RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
 
+		Expect(dockerfile).ToNot(ContainSubstring(`discourse-builder`))
 		Expect(dockerfile).ToNot(ContainSubstring(`discourse-slim`))
 	})
 
@@ -100,6 +101,7 @@ EXPOSE 90
 COPY config.yaml /temp-config.yaml
 RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
 CMD ["/sbin/boot"]`))
+		Expect(dockerfile).ToNot(ContainSubstring(`discourse-builder`))
 		Expect(dockerfile).ToNot(ContainSubstring(`discourse-slim`))
 	})
 

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Config", func() {
 	})
 
 	It("can convert pups config to dockerfile format and bake in default env", func() {
-		dockerfile := conf.Dockerfile("", false, false, "config.yaml")
+		dockerfile := conf.Dockerfile(false, false, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
 ARG LANG
 ARG LANGUAGE
@@ -68,7 +68,7 @@ CMD ["/sbin/boot"]`))
 	})
 
 	It("can generate a dockerfile with all env baked into the image", func() {
-		dockerfile := conf.Dockerfile("", true, false, "config.yaml")
+		dockerfile := conf.Dockerfile(true, false, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
 ARG LANG
 ARG LANGUAGE
@@ -101,7 +101,7 @@ CMD ["/sbin/boot"]`))
 	})
 
 	It("can generate a dockerfile that includes volume mounts", func() {
-		dockerfile := conf.Dockerfile("", false, true, "config.yaml")
+		dockerfile := conf.Dockerfile(false, true, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image}
 ARG LANG
 ARG LANGUAGE

--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -23,7 +22,6 @@ type DockerBuilder struct {
 	Dir          string
 	ImageTag     string
 	ExtraFlags   []string
-	MountVolumes bool
 }
 
 func (r *DockerBuilder) Run(ctx context.Context) error {
@@ -56,13 +54,6 @@ func (r *DockerBuilder) Run(ctx context.Context) error {
 		cmd.Args = append(cmd.Args, r.ImageTag)
 	}
 	cmd.Args = append(cmd.Args, "--shm-size=512m")
-
-	if r.MountVolumes {
-		for i, v := range r.Config.Volumes {
-			cmd.Args = append(cmd.Args, "--build-context")
-			cmd.Args = append(cmd.Args, "volume_"+strconv.Itoa(i)+"="+v.Volume.Host)
-		}
-	}
 
 	cmd.Args = append(cmd.Args, r.ExtraFlags...)
 	cmd.Args = append(cmd.Args, "-f")

--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -17,11 +17,11 @@ import (
 )
 
 type DockerBuilder struct {
-	Config       *config.Config
-	Stdin        io.Reader
-	Dir          string
-	ImageTag     string
-	ExtraFlags   []string
+	Config     *config.Config
+	Stdin      io.Reader
+	Dir        string
+	ImageTag   string
+	ExtraFlags []string
 }
 
 func (r *DockerBuilder) Run(ctx context.Context) error {

--- a/v2/docker/commands_test.go
+++ b/v2/docker/commands_test.go
@@ -65,22 +65,5 @@ var _ = Describe("Commands", func() {
 				Expect(cmd.Env).To(ContainElement("launcher_test=testval"))
 			})
 		})
-
-		Context("With volume mounts", func() {
-			BeforeEach(func() {
-				conf = &config.Config{Name: "test", Volumes: []config.VolumeObject{
-					{Volume: config.Volume{Host: "/host/path1", Guest: "/guest/path1"}},
-					{Volume: config.Volume{Host: "/host/path2", Guest: "/guest/path2"}},
-				}}
-			})
-			It("is able to build with specified mounts", func() {
-				runner := docker.DockerBuilder{Config: conf, Stdin: nil, ImageTag: "test/test", MountVolumes: true}
-				runner.Run(ctx) //nolint:errcheck
-				cmd := GetLastCommand()
-				Expect(cmd.String()).To(ContainSubstring("--build-context"))
-				Expect(cmd.String()).To(ContainSubstring("volume_0=/host/path1"))
-				Expect(cmd.String()).To(ContainSubstring("volume_1=/host/path2"))
-			})
-		})
 	})
 })

--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const Version = "v2.2.1"
+const Version = "v2.3.0"
 
 const DefaultNamespace = "local_discourse"
 


### PR DESCRIPTION
Add (experimental) option for a slim image build using a separate base image. Copies all required runtime assets rather than compiling them by hand.

Remove unused cache mounting option for simplicity.