### PR TITLE
FIX: append final env in rawYaml for pups run

### DIFF
--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -136,6 +136,16 @@ func LoadConfig(dir string, configName string, includeTemplates bool, templatesD
 		config.Env[k] = val
 	}
 
+	// Append env to final raw yaml to replace {{config}} entries
+	// This allows pups to also get the properly replaced {{config}} values
+	// as pups does not do any replacement on its own.
+	// Appending env ensures last write wins.
+	envStr, err := yaml.Marshal(Config{Env: config.Env})
+	if err != nil {
+		return nil, err
+	}
+	config.rawYaml = append(config.rawYaml, string(envStr))
+
 	if config.BaseImage == "" {
 		return nil, errors.New("no base image specified in config, set base image with `base_image: {imagename}`")
 	}

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -39,6 +39,15 @@ var _ = Describe("Config", func() {
 		Expect(string(out[:])).To(ContainSubstring("DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'"))
 	})
 
+	It("appends {{config}} replaced env values to the raw yaml config", func() {
+		err := conf.WriteYamlConfig(testDir, "config.yaml")
+		Expect(err).To(BeNil())
+		out, err := os.ReadFile(testDir + "/config.yaml")
+		Expect(err).To(BeNil())
+		Expect(strings.Contains(string(out[:]), ""))
+		Expect(string(out[:])).To(ContainSubstring("REPLACED: test/test/test"))
+	})
+
 	It("can convert pups config to dockerfile format and bake in default env", func() {
 		dockerfile := conf.Dockerfile(false, false, "config.yaml")
 		Expect(dockerfile).To(ContainSubstring(`FROM ${dockerfile_from_image} AS discourse-full

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -35,7 +35,6 @@ var _ = Describe("Config", func() {
 		Expect(err).To(BeNil())
 		out, err := os.ReadFile(testDir + "/config.yaml")
 		Expect(err).To(BeNil())
-		Expect(strings.Contains(string(out[:]), ""))
 		Expect(string(out[:])).To(ContainSubstring("DISCOURSE_DEVELOPER_EMAILS: 'me@example.com,you@example.com'"))
 	})
 
@@ -44,7 +43,6 @@ var _ = Describe("Config", func() {
 		Expect(err).To(BeNil())
 		out, err := os.ReadFile(testDir + "/config.yaml")
 		Expect(err).To(BeNil())
-		Expect(strings.Contains(string(out[:]), ""))
 		Expect(string(out[:])).To(ContainSubstring("REPLACED: test/test/test"))
 	})
 

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"errors"
 	"os"
-	"strings"
 
 	"github.com/discourse/launcher/v2/config"
 )

--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const Version = "v2.3.1"
+const Version = "v2.3.2"
 
 const DefaultNamespace = "local_discourse"
 


### PR DESCRIPTION
Raw yaml that is passed to pups does not do {{config}} replacements on its own. To allow pups to see the {{config}} replacements, append the raw yaml with a modified env block which contains the {{config}} replacements

append env to ensure last write wins