### PR TITLE
Buildx build

### DIFF
--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -33,7 +33,7 @@ func (r *DockerBuilder) Run(ctx context.Context) error {
 	if r.ImageTag == "" {
 		r.ImageTag = utils.DefaultNamespace + "/" + r.Config.Name
 	}
-	cmd := exec.CommandContext(ctx, utils.DockerPath, "build")
+	cmd := exec.CommandContext(ctx, utils.DockerPath, "buildx", "build")
 	TimeoutDockerBuild(cmd)
 	cmd.Dir = r.Dir
 	cmd.Env = os.Environ()

--- a/v2/utils/consts.go
+++ b/v2/utils/consts.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const Version = "v2.3.2"
+const Version = "v2.3.3"
 
 const DefaultNamespace = "local_discourse"
 


### PR DESCRIPTION
use buildx build: allows launcher to take advantage of default custom builders out of the box without having to set via `--builder` arg or `BUILDX_BUILDER` env var.

Allows for more flexible builds, where `launcher build` can use configured buildx builders by default.