### PR TITLE
Use bind-mount for pups yaml

### DIFF
--- a/v2/cli_build_test.go
+++ b/v2/cli_build_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Build", func() {
 			buf := new(strings.Builder)
 			io.Copy(buf, cmd.Stdin) //nolint:errcheck
 			// docker build's stdin is a dockerfile
-			Expect(buf.String()).To(ContainSubstring("COPY config.yaml /temp-config.yaml"))
+			Expect(buf.String()).To(ContainSubstring("RUN --mount=type=bind,source=config.yaml,target=/temp-config.yaml"))
 			Expect(buf.String()).To(ContainSubstring("--skip-tags=precompile,migrate,db"))
 			Expect(buf.String()).ToNot(ContainSubstring("SKIP_EMBER_CLI_COMPILE=1"))
 

--- a/v2/config/config.go
+++ b/v2/config/config.go
@@ -188,13 +188,9 @@ func (config *Config) Dockerfile(bakeEnv bool, buildSlim bool, configFile string
 		builder.WriteString(config.dockerfileDefaultEnvs() + "\n")
 	}
 	builder.WriteString(config.dockerfileExpose() + "\n")
-	builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
-
-	builder.WriteString("RUN ")
-
+	builder.WriteString("RUN --mount=type=bind,source=" + configFile + ",target=/temp-config.yaml ")
 	builder.WriteString(
-		"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin " +
-			"&& rm /temp-config.yaml\n")
+		"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin\n")
 	builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]\n")
 
 	if buildSlim {
@@ -216,7 +212,6 @@ func (config *Config) Dockerfile(bakeEnv bool, buildSlim bool, configFile string
 			builder.WriteString(config.dockerfileDefaultEnvs() + "\n")
 		}
 		builder.WriteString(config.dockerfileExpose() + "\n")
-		builder.WriteString("COPY " + configFile + " /temp-config.yaml\n")
 		// copy full build
 		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules --exclude=**/libv8_monolith.a /var/www/discourse/ /var/www/discourse\n")
 		// copy pnpm lock, used for calculating asset processor
@@ -232,10 +227,9 @@ func (config *Config) Dockerfile(bakeEnv bool, buildSlim bool, configFile string
 		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/ /var/www/discourse/frontend/discourse/node_modules/@highlightjs/cdn-assets/\n")
 		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales /var/www/discourse/node_modules/@discourse/moment-timezone-names-translations/locales\n")
 		builder.WriteString("COPY --chown=discourse:discourse --from=discourse-builder /var/www/discourse/frontend/discourse/node_modules/moment/locale /var/www/discourse/frontend/discourse/node_modules/moment/locale\n")
-		builder.WriteString("RUN ")
+		builder.WriteString("RUN --mount=type=bind,source=" + configFile + ",target=/temp-config.yaml ")
 		builder.WriteString(
-			"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=build,precompile,migrate,db --stdin " +
-				"&& rm /temp-config.yaml\n")
+			"cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=build,precompile,migrate,db --stdin\n")
 		builder.WriteString("CMD [\"" + config.GetBootCommand() + "\"]\n")
 	}
 

--- a/v2/config/config_test.go
+++ b/v2/config/config_test.go
@@ -68,8 +68,7 @@ ENV UNICORN_WORKERS=${UNICORN_WORKERS}
 EXPOSE 443
 EXPOSE 80
 EXPOSE 90
-COPY config.yaml /temp-config.yaml
-RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
+RUN --mount=type=bind,source=config.yaml,target=/temp-config.yaml cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin
 CMD ["/sbin/boot"]`))
 
 		Expect(dockerfile).ToNot(ContainSubstring(`discourse-builder`))
@@ -104,8 +103,7 @@ ENV UNICORN_WORKERS=${UNICORN_WORKERS}
 EXPOSE 443
 EXPOSE 80
 EXPOSE 90
-COPY config.yaml /temp-config.yaml
-RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
+RUN --mount=type=bind,source=config.yaml,target=/temp-config.yaml cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin
 CMD ["/sbin/boot"]`))
 		Expect(dockerfile).ToNot(ContainSubstring(`discourse-builder`))
 		Expect(dockerfile).ToNot(ContainSubstring(`discourse-slim`))
@@ -134,8 +132,7 @@ ENV UNICORN_WORKERS=${UNICORN_WORKERS}
 EXPOSE 443
 EXPOSE 80
 EXPOSE 90
-COPY config.yaml /temp-config.yaml
-RUN cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin && rm /temp-config.yaml
+RUN --mount=type=bind,source=config.yaml,target=/temp-config.yaml cat /temp-config.yaml | /usr/local/bin/pups --skip-tags=precompile,migrate,db --stdin
 CMD ["/sbin/boot"]
 
 FROM discourse-full AS discourse-builder
@@ -176,7 +173,6 @@ ENV UNICORN_WORKERS=${UNICORN_WORKERS}
 EXPOSE 443
 EXPOSE 80
 EXPOSE 90
-COPY config.yaml /temp-config.yaml
 COPY --chown=discourse:discourse --from=discourse-builder --exclude=.git --exclude=tmp --exclude=**/node_modules --exclude=**/libv8_monolith.a /var/www/discourse/ /var/www/discourse`))
 	})
 


### PR DESCRIPTION
Using a separate COPY instruction for the pups yaml means that it persists forever in the image layers, even though it's deleted in the following RUN. This isn't ideal, because the yaml may include secrets which wouldn't otherwise be persisted in the image.

Instead, we can use `RUN --mount=type=bind` to make the yaml temporarily available within the RUN command, without being persisted to the image.

`RUN --mount=type=bind` has been supported in BuildKit-enabled Docker since 20.10 (verified on 20.10.5).