### PR TITLE
Force BuildKit when invoking docker build

### DIFF
--- a/v2/docker/commands.go
+++ b/v2/docker/commands.go
@@ -39,6 +39,7 @@ func (r *DockerBuilder) Run(ctx context.Context) error {
 	cmd.Env = os.Environ()
 	env := r.Config.GetEnvSlice(false)
 	cmd.Env = append(cmd.Env, env...)
+	cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=1")
 	cmd.Env = append(cmd.Env, "BUILDKIT_PROGRESS=plain")
 	for k := range r.Config.Env {
 		if !slices.Contains(utils.KnownSecrets, k) {


### PR DESCRIPTION
The generated Dockerfile uses `RUN --mount=type=bind`, which requires BuildKit. On daemons where BuildKit is not the default builder (notably docker.io 20.10 as shipped on Debian bookworm), plain docker build falls back to the legacy builder and fails with "the --mount option requires BuildKit". Set DOCKER_BUILDKIT=1 alongside the existing BUILDKIT_PROGRESS so the BuildKit backend is used regardless of the daemon default.